### PR TITLE
Update UI colors to matte theme

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -9,7 +9,7 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
 		<link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
-		<link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#00316b">
+                <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#345575">
 		<link rel="shortcut icon" href="/favicons/favicon.ico">
 		<meta name="apple-mobile-web-app-title" content="League Page">
 		<meta name="application-name" content="League Page">

--- a/src/lib/BlogPosts/Post.svelte
+++ b/src/lib/BlogPosts/Post.svelte
@@ -164,7 +164,7 @@
     }
 
     .authorAndDate a {
-        background-color: #00316b;
+        background-color: #345575;
         color: #fff;
         border-radius: 1em;
         text-decoration: none;
@@ -174,7 +174,7 @@
     }
 
     .authorAndDate a:hover {
-        background-color: #0082c3;
+        background-color: #7ca0c0;
     }
 
     :global(.body blockquote) {

--- a/src/lib/BlogPosts/Posts.svelte
+++ b/src/lib/BlogPosts/Posts.svelte
@@ -113,11 +113,11 @@
     }
 
     .filterLink {
-        background-color: #00316b;
+        background-color: #345575;
     }
 
     .filterLink:not(.noHover):hover {
-        background-color: #0082c3;
+        background-color: #7ca0c0;
     }
 
     .noHover {

--- a/src/lib/Matchups/Matchup.svelte
+++ b/src/lib/Matchups/Matchup.svelte
@@ -159,7 +159,7 @@
 
     :global(.homeGlow) {
         box-shadow: 0 0 6px 4px #3279cf;
-        background-color: #00316b !important;
+        background-color: #345575 !important;
     }
 
     .away {

--- a/src/lib/Matchups/MatchupWeeks.svelte
+++ b/src/lib/Matchups/MatchupWeeks.svelte
@@ -72,7 +72,7 @@
     }
 
     :global(.changeWeek:hover) {
-        color: #00316b;
+        color: #345575;
     }
 
     .spacer {

--- a/src/lib/Nav/NavLarge.svelte
+++ b/src/lib/Nav/NavLarge.svelte
@@ -135,7 +135,7 @@
 			</Tab>
 		{/if}
 	</TabBar>
-	<div class="subMenu" style="max-height: {display ? 49 * tabChildren.length - 1 - (managers.length ? 0 : 48) : 0}px; width: {width}px; top: {height}px; left: {left}px; box-shadow: 0 0 {display ? "3px" : "0"} 0 #00316b; border: {display ? "1px" : "0"} solid #00316b; border-top: none;">
+       <div class="subMenu" style="max-height: {display ? 49 * tabChildren.length - 1 - (managers.length ? 0 : 48) : 0}px; width: {width}px; top: {height}px; left: {left}px; box-shadow: 0 0 {display ? "3px" : "0"} 0 #345575; border: {display ? "1px" : "0"} solid #345575; border-top: none;">
 		<List>
 			{#each tabChildren as subTab, ix}
 				{#if subTab.label == 'Managers'}

--- a/src/lib/Nav/NavSmall.svelte
+++ b/src/lib/Nav/NavSmall.svelte
@@ -32,9 +32,9 @@
 		cursor: pointer;
 	}
 
-	:global(.menuIcon:hover) {
-		color: #00316b;
-	}
+        :global(.menuIcon:hover) {
+                color: #345575;
+        }
 
 	:global(.nav-drawer) {
 		z-index: 5;

--- a/src/lib/Nav/index.svelte
+++ b/src/lib/Nav/index.svelte
@@ -43,8 +43,8 @@
 		background-color: var(--fff);
 		position: relative;
 		z-index: 2;
-		border-bottom: 1px solid #00316b;
-		box-shadow: 0 0 8px 0 #00316b;
+                border-bottom: 1px solid #345575;
+                box-shadow: 0 0 8px 0 #345575;
 	}
 
 	#logo {

--- a/src/lib/Pagination.svelte
+++ b/src/lib/Pagination.svelte
@@ -42,7 +42,7 @@
     }
 
     :global(.button:hover) {
-        color: #0082c3;
+        color: #7ca0c0;
     }
 
     .paginationBar {
@@ -71,7 +71,7 @@
     }
 
     .dest:hover {
-        color: #0082c3;
+        color: #7ca0c0;
     }
 
     .selected {

--- a/src/lib/Transactions/Transactions.svelte
+++ b/src/lib/Transactions/Transactions.svelte
@@ -54,9 +54,9 @@
 		margin-bottom: 10px;
 	}
 
-	.link:hover {
-		color: #00316b;
-	}
+        .link:hover {
+                color: #345575;
+        }
 
 	.nothingYet {
 		margin: 5em 0;

--- a/src/routes/constitution/index.svelte
+++ b/src/routes/constitution/index.svelte
@@ -91,7 +91,7 @@
     }
 
     .clickable:hover {
-        color: #00316b;
+        color: #345575;
     }
 
     p {

--- a/src/theme/_smui-theme.scss
+++ b/src/theme/_smui-theme.scss
@@ -1,18 +1,18 @@
-@use 'sass:color';
+@use "sass:color";
 
-@use '@material/theme/color-palette';
+@use "@material/theme/color-palette";
 
 // Svelte Colors!
-@use '@material/theme/index' as theme with (
-  $primary: #00316b,
-  $secondary: #0082c3,
+@use "@material/theme/index" as theme with (
+  $primary: #345575,
+  $secondary: #7ca0c0,
   $surface: #fff,
   $background: #fff,
-  $error: color-palette.$red-900,
+  $error: color-palette.$red-900
 );
 
 // Import all the styles for the classes.
-@use '@material/typography/mdc-typography';
+@use "@material/typography/mdc-typography";
 // The following classes become available:
 //   mdc-typography--headline1
 //   mdc-typography--headline2
@@ -28,9 +28,9 @@
 //   mdc-typography--button
 //   mdc-typography--overline
 //   mdc-typography--body1
- 
+
 // Import the mixins.
-@use '@material/typography/index' as typography;
+@use "@material/typography/index" as typography;
 
 :root {
   --fff: #fff;
@@ -64,35 +64,35 @@
   --fadeTwo: rgba(255, 255, 255, 0.7) 50%;
   --fadeThree: rgba(255, 255, 255, 0.9) 90%;
   --fadeFour: rgba(255, 255, 255, 1) 100%;
-  --blueOne: #00316b;
+  --blueOne: #345575;
   --r1: #f7f9fd;
   --r2: #fbf7f7;
   --r3: #f7fbf7;
   // Positions
-  --QBfade: #ff8fb2;
-  --WRfade: #afd4ff;
-  --RBfade: #6ccac1;
-  --TEfade: #ffd6aa;
-  --Kfade: #deb4ff;
-  --DEfadeFfade: #fffbbc;
-  --PICKSfade: #73b647;
-  --CBfade: #ffcc7a;
-  --SSfade: #b7a1db;
-  --FSfade: #ebe7b3;
-  --DEfade: #b1d0e9;
-  --DLfade: #c392d3;
-  --LBfade: #98c097;
+  --QBfade: #ecc0c0;
+  --WRfade: #c0d3ec;
+  --RBfade: #c0e0d2;
+  --TEfade: #ecd1c0;
+  --Kfade: #d8c8ec;
+  --DEfadeFfade: #ece6c0;
+  --PICKSfade: #c9dabc;
+  --CBfade: #ecd9c0;
+  --SSfade: #d4c0e0;
+  --FSfade: #ece4c9;
+  --DEfade: #d0dbe6;
+  --DLfade: #e2c9d8;
+  --LBfade: #c6cadf;
 
-	--QB: #ff2a6d;
-	--WR: #58a7ff;
-	--RB: #00ceb8;
-	--TE: #ffae58;
-	--K: #bd66ff;
-	--DEF: #fff67a;
-	--DL: #ff795a;
-	--LB: #6d7df5;
-	--DB: #ff7cb6;
-	--BN: #b6d0eb;
+  --QB: #c94c4c;
+  --WR: #4c82c9;
+  --RB: #4ca96b;
+  --TE: #c98b4c;
+  --K: #9c6acd;
+  --DEF: #d1c75c;
+  --DL: #c96c5a;
+  --LB: #6c75c9;
+  --DB: #c96c9c;
+  --BN: #a8b6c9;
 }
 
 html,
@@ -102,61 +102,61 @@ body {
   background-color: theme.$surface;
   color: theme.$on-surface;
   min-height: 100vh;
-  background: #f4f4f4;
-  background: linear-gradient(to bottom right, #f4f4f4,#ebebeb );
-  background: -webkit-linear-gradient(to bottom right, #f4f4f4,#ebebeb );
+  background: #efefef;
+  background: linear-gradient(to bottom right, #efefef, #dcdcdc);
+  background: -webkit-linear-gradient(to bottom right, #efefef, #dcdcdc);
 }
- 
+
 //
 // Some defaults that may be helpful to you.
 // If you just want to use these, and not the classes, you can instead just
 // @use '@material/typography/index' as typography, and your CSS file will be smaller.
 //
 html {
-  @include typography.typography('body1');
+  @include typography.typography("body1");
 }
- 
+
 h1 {
-  @include typography.typography('headline1');
+  @include typography.typography("headline1");
 }
- 
+
 h2 {
-  @include typography.typography('headline2');
+  @include typography.typography("headline2");
 }
- 
+
 h3 {
-  @include typography.typography('headline3');
+  @include typography.typography("headline3");
 }
- 
+
 h4 {
-  @include typography.typography('headline4');
+  @include typography.typography("headline4");
 }
- 
+
 h5 {
-  @include typography.typography('headline5');
+  @include typography.typography("headline5");
 }
- 
+
 h6 {
-  @include typography.typography('headline6');
+  @include typography.typography("headline6");
 }
- 
+
 caption {
-  @include typography.typography('caption');
+  @include typography.typography("caption");
 }
- 
+
 code,
 pre {
-  font-family: 'Roboto Mono', monospace;
+  font-family: "Roboto Mono", monospace;
 }
- 
+
 small {
   font-size: 0.9em;
 }
- 
+
 big {
   font-size: 1.1em;
 }
- 
+
 b,
 strong {
   font-weight: bold;
@@ -176,7 +176,7 @@ a:visited {
 }
 
 .mdc-button--raised {
-  background-image: linear-gradient(135deg, var(--blueOne), #00b2ff);
+  background-image: linear-gradient(135deg, var(--blueOne), #5c87a8);
   color: #fff;
 }
 

--- a/src/theme/dark/_smui-theme.scss
+++ b/src/theme/dark/_smui-theme.scss
@@ -1,18 +1,18 @@
-@use 'sass:color';
+@use "sass:color";
 
-@use '@material/theme/color-palette';
+@use "@material/theme/color-palette";
 
 // Svelte Colors!
-@use '@material/theme/index' as theme with (
-  $primary: #0082c3,
-  $secondary: #00316b,
+@use "@material/theme/index" as theme with (
+  $primary: #7ca0c0,
+  $secondary: #345575,
   $surface: #000000,
   $background: #000000,
-  $error: color-palette.$red-900,
+  $error: color-palette.$red-900
 );
 
 // Import all the styles for the classes.
-@use '@material/typography/mdc-typography';
+@use "@material/typography/mdc-typography";
 // The following classes become available:
 //   mdc-typography--headline1
 //   mdc-typography--headline2
@@ -28,9 +28,9 @@
 //   mdc-typography--button
 //   mdc-typography--overline
 //   mdc-typography--body1
- 
+
 // Import the mixins.
-@use '@material/typography/index' as typography;
+@use "@material/typography/index" as typography;
 
 :root {
   --fff: #000000;
@@ -64,35 +64,35 @@
   --fadeTwo: rgba(0, 0, 0, 0.7) 50%;
   --fadeThree: rgba(0, 0, 0, 0.9) 90%;
   --fadeFour: rgba(0, 0, 0, 1) 100%;
-  --blueOne: #0082c3;
+  --blueOne: #7ca0c0;
   --r1: #1c1c1d;
   --r2: #1f1d1d;
   --r3: #181a18;
   // Positions
-  --QBfade: #ff8fb2;
-  --WRfade: #afd4ff;
-  --RBfade: #6ccac1;
-  --TEfade: #ffd6aa;
-  --Kfade: #deb4ff;
-  --DEfadeFfade: #fffbbc;
-  --PICKSfade: #73b647;
-  --CBfade: #ffcc7a;
-  --SSfade: #b7a1db;
-  --FSfade: #ebe7b3;
-  --DEfade: #b1d0e9;
-  --DLfade: #c392d3;
-  --LBfade: #98c097;
+  --QBfade: #ecc0c0;
+  --WRfade: #c0d3ec;
+  --RBfade: #c0e0d2;
+  --TEfade: #ecd1c0;
+  --Kfade: #d8c8ec;
+  --DEfadeFfade: #ece6c0;
+  --PICKSfade: #c9dabc;
+  --CBfade: #ecd9c0;
+  --SSfade: #d4c0e0;
+  --FSfade: #ece4c9;
+  --DEfade: #d0dbe6;
+  --DLfade: #e2c9d8;
+  --LBfade: #c6cadf;
 
-	--QB: #ff2a6d;
-	--WR: #58a7ff;
-	--RB: #00ceb8;
-	--TE: #ffae58;
-	--K: #bd66ff;
-	--DEF: #fff67a;
-	--DL: #ff795a;
-	--LB: #6d7df5;
-	--DB: #ff7cb6;
-	--BN: #b6d0eb;
+  --QB: #c94c4c;
+  --WR: #4c82c9;
+  --RB: #4ca96b;
+  --TE: #c98b4c;
+  --K: #9c6acd;
+  --DEF: #d1c75c;
+  --DL: #c96c5a;
+  --LB: #6c75c9;
+  --DB: #c96c9c;
+  --BN: #a8b6c9;
 }
 
 html,
@@ -102,61 +102,61 @@ body {
   background-color: theme.$surface;
   color: theme.$on-surface;
   min-height: 100vh;
-  background: #222;
-  background: linear-gradient(to bottom right, #111,#222 );
-  background: -webkit-linear-gradient(to bottom right, #111,#222 );
+  background: #1a1a1a;
+  background: linear-gradient(to bottom right, #1a1a1a, #2a2a2a);
+  background: -webkit-linear-gradient(to bottom right, #1a1a1a, #2a2a2a);
 }
- 
+
 //
 // Some defaults that may be helpful to you.
 // If you just want to use these, and not the classes, you can instead just
 // @use '@material/typography/index' as typography, and your CSS file will be smaller.
 //
 html {
-  @include typography.typography('body1');
+  @include typography.typography("body1");
 }
- 
+
 h1 {
-  @include typography.typography('headline1');
+  @include typography.typography("headline1");
 }
- 
+
 h2 {
-  @include typography.typography('headline2');
+  @include typography.typography("headline2");
 }
- 
+
 h3 {
-  @include typography.typography('headline3');
+  @include typography.typography("headline3");
 }
- 
+
 h4 {
-  @include typography.typography('headline4');
+  @include typography.typography("headline4");
 }
- 
+
 h5 {
-  @include typography.typography('headline5');
+  @include typography.typography("headline5");
 }
- 
+
 h6 {
-  @include typography.typography('headline6');
+  @include typography.typography("headline6");
 }
- 
+
 caption {
-  @include typography.typography('caption');
+  @include typography.typography("caption");
 }
- 
+
 code,
 pre {
-  font-family: 'Roboto Mono', monospace;
+  font-family: "Roboto Mono", monospace;
 }
- 
+
 small {
   font-size: 0.9em;
 }
- 
+
 big {
   font-size: 1.1em;
 }
- 
+
 b,
 strong {
   font-weight: bold;
@@ -176,7 +176,7 @@ a:visited {
 }
 
 .mdc-button--raised {
-  background-image: linear-gradient(135deg, var(--blueOne), #0074b9);
+  background-image: linear-gradient(135deg, var(--blueOne), #5c87a8);
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- adopt new matte color palette for Svelte Material UI themes
- update navigation and components to use matte accent color
- adjust button gradients and default backgrounds
- update mask-icon color reference

## Testing
- `npm run lint` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685c133108d083238cfb13c0e0f643e2