### PR TITLE
Add league history view

### DIFF
--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -15,3 +15,4 @@ export const news = writable([]);
 export const posts = writable([]);
 export const brackets = writable({});
 export const standingsStore = writable({});
+export const leagueHistory = writable([]);

--- a/src/lib/utils/helper.js
+++ b/src/lib/utils/helper.js
@@ -16,6 +16,7 @@ import { predictScores } from './helperFunctions/predictOptimalScore';
 import { getBrackets } from './helperFunctions/leagueBrackets';
 import { getBlogPosts } from './helperFunctions/getBlogPosts';
 import { getLeagueStandings } from './helperFunctions/leagueStandings';
+import { getLeagueHistory } from './helperFunctions/leagueHistory';
 
 export {
     enableBlog,
@@ -47,6 +48,7 @@ export {
     getBlogPosts,
     predictScores,
     getLeagueStandings,
+    getLeagueHistory,
     getAuthor,
     parseDate,
     getAvatar,

--- a/src/lib/utils/helperFunctions/leagueHistory.js
+++ b/src/lib/utils/helperFunctions/leagueHistory.js
@@ -1,0 +1,25 @@
+import { leagueID } from '$lib/utils/leagueInfo';
+import { leagueHistory } from '$lib/stores';
+import { get } from 'svelte/store';
+import { getLeagueData } from './leagueData';
+
+export const getLeagueHistory = async () => {
+    if (get(leagueHistory).length > 0) {
+        return get(leagueHistory);
+    }
+
+    const history = [];
+    let current = leagueID;
+
+    while (current && current != 0) {
+        const data = await getLeagueData(current).catch((err) => {
+            console.error(err);
+        });
+        if (!data) break;
+        history.push({ season: data.season, league_id: current });
+        current = data.previous_league_id;
+    }
+
+    leagueHistory.set(history);
+    return history;
+};

--- a/src/lib/utils/tabs.js
+++ b/src/lib/utils/tabs.js
@@ -74,6 +74,11 @@ export const tabs = [
                 dest: '/records',
             },
             {
+                icon: 'history',
+                label: 'Leagues',
+                dest: '/leagues',
+            },
+            {
                 icon: 'history_edu',
                 label: 'Constitution',
                 dest: '/constitution',

--- a/src/routes/leagues/index.svelte
+++ b/src/routes/leagues/index.svelte
@@ -1,0 +1,66 @@
+<script context="module">
+    import { getLeagueHistory } from '$lib/utils/helper';
+
+    export async function load() {
+        const leaguesData = getLeagueHistory();
+        return { props: { leaguesData } };
+    }
+</script>
+
+<script>
+    import LinearProgress from '@smui/linear-progress';
+    export let leaguesData;
+</script>
+
+<style>
+    #main {
+        position: relative;
+        z-index: 1;
+        display: block;
+        margin: 30px auto;
+        width: 95%;
+        max-width: 600px;
+    }
+    .loading {
+        display: block;
+        width: 85%;
+        max-width: 500px;
+        margin: 80px auto;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+    td, th {
+        padding: 8px;
+        border-bottom: 1px solid var(--g555);
+    }
+    th {
+        text-align: left;
+    }
+</style>
+
+<div id="main">
+    {#await leaguesData}
+        <div class="loading">
+            <p>Fetching league history...</p>
+            <LinearProgress indeterminate />
+        </div>
+    {:then history}
+        <table>
+            <thead>
+                <tr><th>Season</th><th>League ID</th></tr>
+            </thead>
+            <tbody>
+                {#each history as item}
+                    <tr>
+                        <td>{item.season}</td>
+                        <td>{item.league_id}</td>
+                    </tr>
+                {/each}
+            </tbody>
+        </table>
+    {:catch error}
+        <p>Something went wrong: {error.message}</p>
+    {/await}
+</div>


### PR DESCRIPTION
## Summary
- list league IDs from previous seasons
- store league history results
- expose league history helper
- include league history in navbar

## Testing
- `npm run lint` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1355fa08832383398c4f4afd79a5