### PR TITLE
Add articles page and updated theme

### DIFF
--- a/src/lib/utils/tabs.js
+++ b/src/lib/utils/tabs.js
@@ -1,98 +1,103 @@
-import {leagueID} from '$lib/utils/leagueInfo';
+import { leagueID } from "$lib/utils/leagueInfo";
 
 export const tabs = [
-    {
-        icon: 'home',
-        label: 'Home',
-        dest: '/',
-    },
-    {
-        icon: 'local_fire_department',
-        label: 'Matchups',
-        dest: '/matchups',
-    },
-    {
-        icon: 'swap_horiz',
-        label: 'Trades & Waivers',
-        dest: '/transactions',
-    },
- //   {
- //       icon: 'swap_horiz',
- //       label: 'Trades & Waivers 2',
- //       nest: true,
- //       children: [
- //           {
- //               icon: 'swap_horiz',
- //               label: 'Recent Transactions',
- //               dest: '/transactions',
- //           },
- //           {
- //               icon: 'swap_horiz',
- //               label: 'Waiver Costs',
- //               dest: '/waivercost',
- //           },
- //       ]
- //   },
-    {
-        icon: 'article',
-        label: 'Blog',
-        dest: '/blog',
-    },
-    {
-        icon: 'view_comfy',
-        label: 'League Info',
-        nest: true,
-        children: [
-            {
-                icon: 'storage',
-                label: 'Rosters',
-                dest: '/rosters',
-            },
-            {
-                icon: 'groups',
-                label: 'Managers',
-                dest: '/managers',
-            },
-            {
-                icon: 'leaderboard',
-                label: 'Standings',
-                dest: '/standings',
-            },
-            {
-                icon: 'view_comfy',
-                label: 'Drafts',
-                dest: '/drafts',
-            },
-            {
-                icon: 'emoji_events',
-                label: 'Trophy Room',
-                dest: '/awards',
-            },
-            {
-                icon: 'military_tech',
-                label: 'Records',
-                dest: '/records',
-            },
-            {
-                icon: 'history',
-                label: 'Leagues',
-                dest: '/leagues',
-            },
-            {
-                icon: 'history_edu',
-                label: 'Constitution',
-                dest: '/constitution',
-            },
-            {
-                icon: 'sports_football',
-                label: 'Go to Sleeper',
-                dest: `https://sleeper.app/leagues/${leagueID}`,
-            },
-        ]
-    },
-    {
-        icon: 'lightbulb',
-        label: 'Resources',
-        dest: '/resources',
-    },
+  {
+    icon: "home",
+    label: "Home",
+    dest: "/",
+  },
+  {
+    icon: "local_fire_department",
+    label: "Matchups",
+    dest: "/matchups",
+  },
+  {
+    icon: "swap_horiz",
+    label: "Trades & Waivers",
+    dest: "/transactions",
+  },
+  //   {
+  //       icon: 'swap_horiz',
+  //       label: 'Trades & Waivers 2',
+  //       nest: true,
+  //       children: [
+  //           {
+  //               icon: 'swap_horiz',
+  //               label: 'Recent Transactions',
+  //               dest: '/transactions',
+  //           },
+  //           {
+  //               icon: 'swap_horiz',
+  //               label: 'Waiver Costs',
+  //               dest: '/waivercost',
+  //           },
+  //       ]
+  //   },
+  {
+    icon: "article",
+    label: "Blog",
+    dest: "/blog",
+  },
+  {
+    icon: "history",
+    label: "Leagues",
+    dest: "/leagues",
+  },
+  {
+    icon: "library_books",
+    label: "Articles",
+    dest: "/articles",
+  },
+  {
+    icon: "view_comfy",
+    label: "League Info",
+    nest: true,
+    children: [
+      {
+        icon: "storage",
+        label: "Rosters",
+        dest: "/rosters",
+      },
+      {
+        icon: "groups",
+        label: "Managers",
+        dest: "/managers",
+      },
+      {
+        icon: "leaderboard",
+        label: "Standings",
+        dest: "/standings",
+      },
+      {
+        icon: "view_comfy",
+        label: "Drafts",
+        dest: "/drafts",
+      },
+      {
+        icon: "emoji_events",
+        label: "Trophy Room",
+        dest: "/awards",
+      },
+      {
+        icon: "military_tech",
+        label: "Records",
+        dest: "/records",
+      },
+      {
+        icon: "history_edu",
+        label: "Constitution",
+        dest: "/constitution",
+      },
+      {
+        icon: "sports_football",
+        label: "Go to Sleeper",
+        dest: `https://sleeper.app/leagues/${leagueID}`,
+      },
+    ],
+  },
+  {
+    icon: "lightbulb",
+    label: "Resources",
+    dest: "/resources",
+  },
 ];

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,6 +1,7 @@
 <!-- __layout.svelte -->
 <script>
-	import { Nav, Footer } from "$lib/components"
+        import { Nav, Footer } from "$lib/components"
+        import { fade } from 'svelte/transition';
     export let activeTab;
 </script>
 
@@ -15,8 +16,10 @@
 
 <div>
     <Nav bind:activeTab={activeTab} /> <!-- adds the nav (small and large) -->
-  
-    <slot activeTab={activeTab} />
+
+    <div transition:fade>
+        <slot activeTab={activeTab} />
+    </div>
 
     <Footer /> <!-- adds the footer -->
 

--- a/src/routes/articles/index.svelte
+++ b/src/routes/articles/index.svelte
@@ -1,0 +1,20 @@
+<script>
+    import LinearProgress from '@smui/linear-progress';
+</script>
+
+<style>
+    #main {
+        position: relative;
+        z-index: 1;
+        display: block;
+        margin: 30px auto;
+        width: 95%;
+        max-width: 800px;
+        text-align: center;
+    }
+</style>
+
+<div id="main">
+    <h2>Articles</h2>
+    <p>AI generated articles will appear here soon.</p>
+</div>

--- a/src/theme/_smui-theme.scss
+++ b/src/theme/_smui-theme.scss
@@ -4,8 +4,8 @@
 
 // Svelte Colors!
 @use "@material/theme/index" as theme with (
-  $primary: #345575,
-  $secondary: #7ca0c0,
+  $primary: #2b4e88,
+  $secondary: #91c0ff,
   $surface: #fff,
   $background: #fff,
   $error: color-palette.$red-900
@@ -64,7 +64,7 @@
   --fadeTwo: rgba(255, 255, 255, 0.7) 50%;
   --fadeThree: rgba(255, 255, 255, 0.9) 90%;
   --fadeFour: rgba(255, 255, 255, 1) 100%;
-  --blueOne: #345575;
+  --blueOne: #2b4e88;
   --r1: #f7f9fd;
   --r2: #fbf7f7;
   --r3: #f7fbf7;
@@ -176,7 +176,7 @@ a:visited {
 }
 
 .mdc-button--raised {
-  background-image: linear-gradient(135deg, var(--blueOne), #5c87a8);
+  background-image: linear-gradient(135deg, var(--blueOne), #4c83c4);
   color: #fff;
 }
 

--- a/src/theme/dark/_smui-theme.scss
+++ b/src/theme/dark/_smui-theme.scss
@@ -4,8 +4,8 @@
 
 // Svelte Colors!
 @use "@material/theme/index" as theme with (
-  $primary: #7ca0c0,
-  $secondary: #345575,
+  $primary: #91c0ff,
+  $secondary: #2b4e88,
   $surface: #000000,
   $background: #000000,
   $error: color-palette.$red-900
@@ -64,7 +64,7 @@
   --fadeTwo: rgba(0, 0, 0, 0.7) 50%;
   --fadeThree: rgba(0, 0, 0, 0.9) 90%;
   --fadeFour: rgba(0, 0, 0, 1) 100%;
-  --blueOne: #7ca0c0;
+  --blueOne: #91c0ff;
   --r1: #1c1c1d;
   --r2: #1f1d1d;
   --r3: #181a18;
@@ -176,7 +176,7 @@ a:visited {
 }
 
 .mdc-button--raised {
-  background-image: linear-gradient(135deg, var(--blueOne), #5c87a8);
+  background-image: linear-gradient(135deg, var(--blueOne), #4c83c4);
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- add articles page and link in navigation
- move league history link to top navigation
- apply simple fade transition to routed pages
- refresh light and dark theme colors

## Testing
- `npm run lint` *(fails: Code style issues found in 41 files)*

------
https://chatgpt.com/codex/tasks/task_e_685c1dff5c888323869181f2a635a771