### PR TITLE
Add integration tests and safer fetch handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Generate a custom league page for your Sleeper fantasy football league in just a few steps
   <br />
-  ![GitHub](https://img.shields.io/github/license/nmelhado/league-page) [![node](https://img.shields.io/badge/node-%3E%3D14-brightgreen)](https://github.com/nmelhado/league-page) ![GitHub top language](https://img.shields.io/github/languages/top/nmelhado/league-page?color=ff3e00) ![Lines of code](https://img.shields.io/tokei/lines/github/nmelhado/league-page?label=lines%20of%20code) ![GitHub forks](https://img.shields.io/github/forks/nmelhado/league-page) ![GitHub pull requests](https://img.shields.io/github/issues-pr/nmelhado/league-page) ![GitHub issues](https://img.shields.io/github/issues-raw/nmelhado/league-page)
+![GitHub](https://img.shields.io/github/license/nmelhado/league-page) [![node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://github.com/nmelhado/league-page) ![GitHub top language](https://img.shields.io/github/languages/top/nmelhado/league-page?color=ff3e00) ![Lines of code](https://img.shields.io/tokei/lines/github/nmelhado/league-page?label=lines%20of%20code) ![GitHub forks](https://img.shields.io/github/forks/nmelhado/league-page) ![GitHub pull requests](https://img.shields.io/github/issues-pr/nmelhado/league-page) ![GitHub issues](https://img.shields.io/github/issues-raw/nmelhado/league-page)
 </div>
 
 
@@ -49,7 +49,7 @@ Generate a custom league page for your Sleeper fantasy football league in just a
 
 
 ## Roadmap
-  - [ ] Add integration tests
+  - [x] Add integration tests
   - [ ] Cleanup repo
   - [x] ~~Test redraft leagues~~
   - [x] ~~Playoff matchups and current bracket~~

--- a/TRAINING_WHEELS.md
+++ b/TRAINING_WHEELS.md
@@ -7,7 +7,7 @@
 Generate a custom league page for your Sleeper fantasy football league in just a few steps
   <br />
 
-  ![GitHub](https://img.shields.io/github/license/nmelhado/league-page) [![node](https://img.shields.io/badge/node-%3E%3D14-brightgreen)](https://github.com/nmelhado/league-page) ![GitHub top language](https://img.shields.io/github/languages/top/nmelhado/league-page?color=ff3e00) ![Lines of code](https://img.shields.io/tokei/lines/github/nmelhado/league-page?label=lines%20of%20code) ![GitHub forks](https://img.shields.io/github/forks/nmelhado/league-page) ![GitHub pull requests](https://img.shields.io/github/issues-pr/nmelhado/league-page) ![GitHub issues](https://img.shields.io/github/issues-raw/nmelhado/league-page)
+![GitHub](https://img.shields.io/github/license/nmelhado/league-page) [![node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://github.com/nmelhado/league-page) ![GitHub top language](https://img.shields.io/github/languages/top/nmelhado/league-page?color=ff3e00) ![Lines of code](https://img.shields.io/tokei/lines/github/nmelhado/league-page?label=lines%20of%20code) ![GitHub forks](https://img.shields.io/github/forks/nmelhado/league-page) ![GitHub pull requests](https://img.shields.io/github/issues-pr/nmelhado/league-page) ![GitHub issues](https://img.shields.io/github/issues-raw/nmelhado/league-page)
 </div>
 
 <div align="center">

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=18.0.0",
     "npm": ">=6.0.0"
   },
   "scripts": {
@@ -53,7 +53,9 @@
     "smui-theme-light": "smui-theme compile static/smui.css -i src/theme",
     "smui-theme-dark": "smui-theme compile static/smui-dark.css -i src/theme/dark",
     "lint": "prettier --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
-    "format": "prettier --write --plugin-search-dir=. ."
+    "format": "prettier --write --plugin-search-dir=. .",
+    "test:e2e": "playwright test",
+    "test": "playwright test"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^1.0.0-next.51",
@@ -65,7 +67,8 @@
     "prettier": "~2.2.1",
     "prettier-plugin-svelte": "^2.2.0",
     "smui-theme": "6.0.0-beta.13",
-    "svelte": "^3.49.0"
+    "svelte": "^3.49.0",
+    "@playwright/test": "^1.39.0"
   },
   "type": "module",
   "dependencies": {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run build && npm run preview -- --port=4173',
+    port: 4173,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  }
+});

--- a/src/lib/utils/helperFunctions/getBlogPosts.js
+++ b/src/lib/utils/helperFunctions/getBlogPosts.js
@@ -1,11 +1,15 @@
 import { get } from 'svelte/store';
 import {posts} from '$lib/stores';
+import { safeFetch } from './universalFunctions';
 
 export const getBlogPosts = async (bypass = false) => {
 	if(get(posts)[0]?.items && !bypass) {
 		return {posts: get(posts), fresh: false};
 	}
-	const res = await fetch('/api/getBlogPosts', {compress: true})
+        const res = await safeFetch('/api/getBlogPosts', {compress: true})
+        if(!res) {
+                return {posts: [], fresh: true};
+        }
     
 	if(!res.ok) {
 		const errs = await res.json();

--- a/src/lib/utils/helperFunctions/leagueBrackets.js
+++ b/src/lib/utils/helperFunctions/leagueBrackets.js
@@ -5,6 +5,7 @@ import { getLeagueUsers } from './leagueUsers';
 import {waitForAll} from './multiPromise';
 import { get } from 'svelte/store';
 import {brackets} from '$lib/stores';
+import { safeFetch } from './universalFunctions';
 
 export const getBrackets = async (queryLeagueID = leagueID) => {
     if(get(brackets).champs && queryLeagueID == leagueID) {
@@ -25,8 +26,8 @@ export const getBrackets = async (queryLeagueID = leagueID) => {
 
     // get bracket data for winners and losers
     const bracketsAndMatchupFetches = [
-        fetch(`https://api.sleeper.app/v1/league/${queryLeagueID}/winners_bracket`, {compress: true}),
-        fetch(`https://api.sleeper.app/v1/league/${queryLeagueID}/losers_bracket`, {compress: true}),
+        safeFetch(`https://api.sleeper.app/v1/league/${queryLeagueID}/winners_bracket`, {compress: true}),
+        safeFetch(`https://api.sleeper.app/v1/league/${queryLeagueID}/losers_bracket`, {compress: true}),
     ]
 
     // variables for playoff records
@@ -53,7 +54,7 @@ export const getBrackets = async (queryLeagueID = leagueID) => {
     // add each week after the regular season to the fetch array
     for(let i = playoffsStart; i < 19; i++) {
         // Get the matchup data (starters) for the playoff weeks
-        bracketsAndMatchupFetches.push(fetch(`https://api.sleeper.app/v1/league/${queryLeagueID}/matchups/${i}`, {compress: true}));
+        bracketsAndMatchupFetches.push(safeFetch(`https://api.sleeper.app/v1/league/${queryLeagueID}/matchups/${i}`, {compress: true}));
     }
     
     // Simultaneously fetch the bracket and matchup data

--- a/src/lib/utils/helperFunctions/leagueData.js
+++ b/src/lib/utils/helperFunctions/leagueData.js
@@ -1,18 +1,22 @@
 import { get } from 'svelte/store';
 import {leagueData} from '$lib/stores';
 import { leagueID } from '$lib/utils/leagueInfo';
+import { safeFetch } from './universalFunctions';
 
 export const getLeagueData = async (queryLeagueID = leagueID) => {
 	if(get(leagueData)[queryLeagueID]) {
 		return get(leagueData)[queryLeagueID];
 	}
-    const res = await fetch(`https://api.sleeper.app/v1/league/${queryLeagueID}`, {compress: true}).catch((err) => { console.error(err); });
-	const data = await res.json().catch((err) => { console.error(err); });
-	
-	if (res.ok) {
-		leagueData.update(ld => {ld[queryLeagueID] = data; return ld});
-		return data;
-	} else {
-		throw new Error(data);
-	}
+    const res = await safeFetch(`https://api.sleeper.app/v1/league/${queryLeagueID}`, {compress: true});
+    if(!res) {
+        return { error: 'Network request failed' };
+    }
+    const data = await res.json().catch((err) => { console.error(err); return null; });
+
+    if (res.ok && data) {
+        leagueData.update(ld => { ld[queryLeagueID] = data; return ld });
+        return data;
+    } else {
+        throw new Error(data || 'Failed to load league data');
+    }
 }

--- a/src/lib/utils/helperFunctions/leagueDrafts.js
+++ b/src/lib/utils/helperFunctions/leagueDrafts.js
@@ -3,6 +3,7 @@ import { leagueID } from '$lib/utils/leagueInfo';
 import { getLeagueRosters } from "./leagueRosters"
 import { getLeagueUsers } from "./leagueUsers"
 import { waitForAll } from './multiPromise';
+import { safeFetch } from './universalFunctions';
 import { get } from 'svelte/store';
 import {upcomingDraft, previousDrafts} from '$lib/stores';
 
@@ -40,10 +41,10 @@ export const getUpcomingDraft = async () => {
 		}
 	}
 
-	const [officialDraftRes, picksRes] = await waitForAll(
-		fetch(`https://api.sleeper.app/v1/draft/${draftID}`, {compress: true}),
-		fetch(`https://api.sleeper.app/v1/league/${leagueID}/traded_picks`, {compress: true}),
-	).catch((err) => { console.error(err); });
+        const [officialDraftRes, picksRes] = await waitForAll(
+                safeFetch(`https://api.sleeper.app/v1/draft/${draftID}`, {compress: true}),
+                safeFetch(`https://api.sleeper.app/v1/league/${leagueID}/traded_picks`, {compress: true}),
+        ).catch((err) => { console.error(err); });
 
 	const [officialDraft, picks] = await waitForAll(
 		officialDraftRes.json(),
@@ -249,11 +250,11 @@ export const getPreviousDrafts = async () => {
 			currentManagers = originalManagers;
 		}
 	
-		const [officialDraftRes, picksRes, playersRes] = await waitForAll(
-			fetch(`https://api.sleeper.app/v1/draft/${draftID}`, {compress: true}),
-			fetch(`https://api.sleeper.app/v1/draft/${draftID}/traded_picks`, {compress: true}),
-			fetch(`https://api.sleeper.app/v1/draft/${draftID}/picks`, {compress: true}),
-		).catch((err) => { console.error(err); });
+                const [officialDraftRes, picksRes, playersRes] = await waitForAll(
+                        safeFetch(`https://api.sleeper.app/v1/draft/${draftID}`, {compress: true}),
+                        safeFetch(`https://api.sleeper.app/v1/draft/${draftID}/traded_picks`, {compress: true}),
+                        safeFetch(`https://api.sleeper.app/v1/draft/${draftID}/picks`, {compress: true}),
+                ).catch((err) => { console.error(err); });
 	
 		const [officialDraft, picks, players] = await waitForAll(
 			officialDraftRes.json(),

--- a/src/lib/utils/helperFunctions/leagueMatchups.js
+++ b/src/lib/utils/helperFunctions/leagueMatchups.js
@@ -4,6 +4,7 @@ import { getNflState } from "./nflState"
 import { getLeagueRosters } from "./leagueRosters"
 import { getLeagueUsers } from "./leagueUsers"
 import { waitForAll } from './multiPromise';
+import { safeFetch } from './universalFunctions';
 import { get } from 'svelte/store';
 import {matchupsStore} from '$lib/stores';
 
@@ -33,7 +34,7 @@ export const getLeagueMatchups = async () => {
 	// pull in all matchup data for the season
 	const matchupsPromises = [];
 	for(let i = 1; i < leagueData.settings.playoff_week_start; i++) {
-		matchupsPromises.push(fetch(`https://api.sleeper.app/v1/league/${leagueID}/matchups/${i}`, {compress: true}))
+                matchupsPromises.push(safeFetch(`https://api.sleeper.app/v1/league/${leagueID}/matchups/${i}`, {compress: true}))
 	}
 	const matchupsRes = await waitForAll(...matchupsPromises);
 

--- a/src/lib/utils/helperFunctions/leagueUsers.js
+++ b/src/lib/utils/helperFunctions/leagueUsers.js
@@ -1,21 +1,25 @@
 import { leagueID } from '$lib/utils/leagueInfo';
 import { get } from 'svelte/store';
 import {users} from '$lib/stores';
+import { safeFetch } from './universalFunctions';
 
 export const getLeagueUsers = async (queryLeagueID = leagueID) => {
 	if(get(users)[queryLeagueID]) {
 		return get(users)[queryLeagueID];
 	}
-	const res = await fetch(`https://api.sleeper.app/v1/league/${queryLeagueID}/users`, {compress: true}).catch((err) => { console.error(err); });
-	const data = await res.json().catch((err) => { console.error(err); });
+        const res = await safeFetch(`https://api.sleeper.app/v1/league/${queryLeagueID}/users`, {compress: true});
+        if(!res) {
+                return { error: 'Network request failed' };
+        }
+        const data = await res.json().catch((err) => { console.error(err); return null; });
 	
-	if (res.ok) {
-		const usersData = processUsers(data);
-		users.update(u => {u[queryLeagueID] = usersData; return u});
-		return usersData;
-	} else {
-		throw new Error(data);
-	}
+        if (res.ok && data) {
+                const usersData = processUsers(data);
+                users.update(u => {u[queryLeagueID] = usersData; return u});
+                return usersData;
+        } else {
+                throw new Error(data || 'Failed to load users');
+        }
 }
 
 const processUsers = (rawUsers) => {

--- a/src/lib/utils/helperFunctions/universalFunctions.js
+++ b/src/lib/utils/helperFunctions/universalFunctions.js
@@ -2,6 +2,15 @@ import { managers } from '$lib/utils/leagueInfo';
 import { goto } from "$app/navigation";
 import { stringDate } from './news';
 
+export const safeFetch = async (url, options) => {
+    try {
+        return await fetch(url, options);
+    } catch (err) {
+        console.error(err);
+        return null;
+    }
+};
+
 export const cleanName = (name) => {
     return name.replace('Team ', '').toLowerCase().replace(/[ ’'!"#$%&\\'()\*+,\-\.\/:;<=>?@\[\\\]\^_`{|}~']/g, "");
 }

--- a/tests/basic.spec.js
+++ b/tests/basic.spec.js
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+const base = 'http://localhost:4173';
+
+test('home page loads', async ({ page }) => {
+  await page.goto(base + '/');
+  await expect(page.locator('h1.leagueName')).toBeVisible();
+});
+
+test('managers page loads', async ({ page }) => {
+  await page.goto(base + '/managers');
+  await expect(page.locator('h2')).toContainText('Managers');
+});


### PR DESCRIPTION
## Summary
- set minimum Node version to 18 and update badges
- add Playwright integration test setup
- implement safeFetch helper
- use safeFetch in various network helpers
- mark roadmap item as complete

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4128e71483239cc627ead350e0a2