### PR TITLE
Add placeholder Articles page

### DIFF
--- a/src/lib/Articles/ArticleCard.svelte
+++ b/src/lib/Articles/ArticleCard.svelte
@@ -1,0 +1,33 @@
+<script>
+  export let title;
+  export let description;
+</script>
+
+<style>
+  .card {
+    background-color: var(--fff);
+    border: 1px solid var(--ccc);
+    border-radius: 1em;
+    box-shadow: 0 0 6px 0 var(--bbb);
+    padding: 1em;
+    margin: 1em;
+    width: 280px;
+  }
+
+  h3 {
+    margin-top: 0;
+    text-align: center;
+    font-size: 1.4em;
+  }
+
+  p {
+    text-align: center;
+    color: var(--g555);
+    margin-bottom: 0;
+  }
+</style>
+
+<div class="card">
+  <h3>{title}</h3>
+  <p>{description}</p>
+</div>

--- a/src/lib/utils/tabs.js
+++ b/src/lib/utils/tabs.js
@@ -84,4 +84,10 @@ export const tabs = [
         dest: '/resources',
         key: 'resources',
     },
+    {
+        icon: 'library_books',
+        label: 'Articles',
+        dest: '/articles',
+        key: 'articles',
+    },
 ];

--- a/src/routes/articles/+page.svelte
+++ b/src/routes/articles/+page.svelte
@@ -1,0 +1,26 @@
+<script>
+  import ArticleCard from '$lib/Articles/ArticleCard.svelte';
+
+  const placeholderArticles = [
+    { title: 'Article Placeholder 1', description: 'AI generated content coming soon.' },
+    { title: 'Article Placeholder 2', description: 'Stay tuned for future updates.' },
+    { title: 'Article Placeholder 3', description: 'More articles will appear here shortly.' }
+  ];
+</script>
+
+<style>
+  #main {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 2em 0;
+  }
+</style>
+
+<div id="main">
+  {#each placeholderArticles as article}
+    <ArticleCard {article.title} {article.description} title={article.title} description={article.description} />
+  {/each}
+</div>


### PR DESCRIPTION
## Summary
- add `ArticleCard` component for simple article blocks
- create `/articles` route with placeholder article cards
- register Articles route in the navbar tabs

## Testing
- `npm run lint` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce40a0eec83238e5ac3ffd718693a