### PR TITLE
Improve transactions UI

### DIFF
--- a/src/routes/transactions/+page.js
+++ b/src/routes/transactions/+page.js
@@ -1,35 +1,44 @@
-import { getLeagueTransactions, loadPlayers, getLeagueTeamManagers } from '$lib/utils/helper';
+import {
+  getLeagueTransactions,
+  loadPlayers,
+  getLeagueTeamManagers,
+} from "$lib/utils/helper";
 
 export async function load({ url, fetch }) {
-    const show = url?.searchParams?.get('show');
-    const query = url?.searchParams?.get('query');
-    const curPage = url?.searchParams?.get('page');
+  const show = url?.searchParams?.get("show");
+  const query = url?.searchParams?.get("query");
+  const curPage = url?.searchParams?.get("page");
+  const seasonParam = url?.searchParams?.get("season");
 
-    const transactionsData = getLeagueTransactions(false);
-    const leagueTeamManagersData = getLeagueTeamManagers();
+  const transactionsData = getLeagueTransactions(false);
+  const leagueTeamManagersData = getLeagueTeamManagers();
 
-    const playersData = loadPlayers(fetch);
+  const playersData = loadPlayers(fetch);
 
-    const bannedValued = [
-        'undefined',
-    ]
+  const bannedValued = ["undefined"];
 
-    const props = {
-        show: "both",
-        query: "",
-        playersData,
-        transactionsData,
-        leagueTeamManagersData,
-        page: 0,
-    }
-    if(show && (show == "trade" || show == "waiver" || show == "both")) {
-        props.show = show;
-    }
-    if(query && !bannedValued.includes(query)) {
-        props.query = query;
-    }
-    if(curPage && !isNaN(curPage)) {
-        props.page = parseInt(curPage) - 1;
-    }
-    return props;
+  const props = {
+    show: "both",
+    query: "",
+    season: "all",
+    playersData,
+    transactionsData,
+    leagueTeamManagersData,
+    page: 0,
+  };
+  if (show && (show == "trade" || show == "waiver" || show == "both")) {
+    props.show = show;
+  }
+  if (query && !bannedValued.includes(query)) {
+    props.query = query;
+  }
+  if (curPage && !isNaN(curPage)) {
+    props.page = parseInt(curPage) - 1;
+  }
+  if (seasonParam && !isNaN(seasonParam)) {
+    props.season = parseInt(seasonParam);
+  } else if (seasonParam === "all") {
+    props.season = "all";
+  }
+  return props;
 }

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -4,7 +4,7 @@
     import { waitForAll } from '$lib/utils/helper';
 
     export let data;
-    const {show, query, page, playersData, transactionsData, leagueTeamManagersData} = data;
+    const {show, query, season, page, playersData, transactionsData, leagueTeamManagersData} = data;
 
 	const perPage = 10;
 </script>
@@ -37,7 +37,7 @@
             <LinearProgress indeterminate />
         </div>
     {:then [{transactions, currentTeams, stale}, playersInfo, leagueTeamManagers]}
-        <TransactionsPage {playersInfo} {stale} {transactions} {currentTeams} {show} {query} queryPage={page} {perPage} postUpdate={true} {leagueTeamManagers} />
+        <TransactionsPage {playersInfo} {stale} {transactions} {currentTeams} {show} {query} {season} queryPage={page} {perPage} postUpdate={true} {leagueTeamManagers} />
     {:catch error}
         <p class="center">Something went wrong: {error.message}</p>
     {/await}


### PR DESCRIPTION
## Summary
- modernize transaction filter buttons and layout
- allow season selection and manager search
- wire season state through page loader

## Testing
- `npm run lint` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce492f7808323bd739ff8ab561ec7