### PR TITLE
Add AI article generator skeleton

### DIFF
--- a/src/lib/ai/agent.js
+++ b/src/lib/ai/agent.js
@@ -1,0 +1,41 @@
+// Utility functions for generating articles using league data
+import {
+  getLeagueData,
+  getLeagueRosters,
+  getLeagueStandings,
+  getNews,
+} from "$lib/utils/helper";
+
+/**
+ * Gather basic league context for article generation.
+ * Returns an object with league data, rosters, standings and news.
+ */
+export async function gatherLeagueContext() {
+  const [league, rosters, standings, news] = await Promise.all([
+    getLeagueData(),
+    getLeagueRosters(),
+    getLeagueStandings(),
+    getNews(),
+  ]);
+
+  return { league, rosters, standings, news };
+}
+
+/**
+ * Generate an article from the provided context.
+ * This is a placeholder implementation.
+ * Integrate your preferred LLM or API here (e.g. OpenAI).
+ */
+export async function generateArticle(context) {
+  // TODO: call your LLM service with the context
+  return `This is a placeholder article for league ${context.league?.name}`;
+}
+
+/**
+ * Publish the generated article.
+ * In production this might save to Contentful or another CMS.
+ */
+export async function publishArticle(article) {
+  // TODO: implement publishing logic
+  return article;
+}

--- a/src/lib/utils/tabs.js
+++ b/src/lib/utils/tabs.js
@@ -26,6 +26,12 @@ export const tabs = [
         key: 'blog',
     },
     {
+        icon: 'description',
+        label: 'Articles',
+        dest: '/articles',
+        key: 'articles',
+    },
+    {
         icon: 'view_comfy',
         label: 'League Info',
         nest: true,

--- a/src/routes/api/generateArticle/+server.js
+++ b/src/routes/api/generateArticle/+server.js
@@ -1,0 +1,18 @@
+import { json } from "@sveltejs/kit";
+import {
+  gatherLeagueContext,
+  generateArticle,
+  publishArticle,
+} from "$lib/ai/agent";
+
+/**
+ * Server endpoint to generate a new article.
+ * Trigger with a POST request once integrated with your LLM provider.
+ */
+export async function POST() {
+  const context = await gatherLeagueContext();
+  const article = await generateArticle(context);
+  const saved = await publishArticle(article);
+
+  return json({ article: saved });
+}

--- a/src/routes/articles/+page.svelte
+++ b/src/routes/articles/+page.svelte
@@ -1,0 +1,16 @@
+<script>
+    // Placeholder page for AI generated articles
+</script>
+
+<style>
+    #main {
+        margin: 30px auto;
+        width: 95%;
+        max-width: 1000px;
+    }
+</style>
+
+<div id="main">
+    <h1>Articles</h1>
+    <p>AI generated articles will appear here.</p>
+</div>


### PR DESCRIPTION
## Summary
- create `agent.js` with helper functions to build AI articles
- add API endpoint for generating articles
- add Articles page and connect it in nav bar

## Testing
- `npm run lint` *(fails: Code style issues found in 58 files)*

------
https://chatgpt.com/codex/tasks/task_e_685ce78bb75c832397df3fcbdf5c9484