### PR TITLE
Improve transactions UI

### DIFF
--- a/src/lib/Transactions/TransactionRow.svelte
+++ b/src/lib/Transactions/TransactionRow.svelte
@@ -1,0 +1,114 @@
+<script>
+  export let transaction;
+  export let players;
+  export let leagueTeamManagers;
+
+  const getTeams = () => {
+    const names = transaction.rosters
+      .map((r) => leagueTeamManagers.teamManagersMap[transaction.season]?.[r]?.team.name)
+      .filter(Boolean);
+    return names.join(' \u2194 ');
+  };
+
+  const getBid = () => {
+    if (transaction.type !== 'waiver') return '';
+    for (const mv of transaction.moves) {
+      for (const col of mv) {
+        if (col?.bid) return col.bid;
+      }
+    }
+    return '';
+  };
+
+  const getDetails = () => {
+    const details = transaction.rosters.map(() => []);
+
+    for (const move of transaction.moves) {
+      const origin = move.findIndex((c) => c === 'origin');
+      for (let i = 0; i < move.length; i++) {
+        const col = move[i];
+        if (!col || col === 'origin') continue;
+
+        let item = '';
+        if (col.player) {
+          const p = players[col.player];
+          item = `${p.fn} ${p.ln}`;
+        } else if (col.pick) {
+          item = `${col.pick.season} R${col.pick.round}`;
+        } else if (col.budget) {
+          item = `${col.budget.amount}$`;
+        }
+
+        if (col.type === 'Added') {
+          item = `<i class="material-icons addIcon">north</i> ${item}`;
+        } else if (col.type === 'Dropped') {
+          item = `<i class="material-icons dropIcon">south</i> ${item}`;
+        } else if (col.type === 'trade') {
+          const fromTeam =
+            origin >= 0
+              ? leagueTeamManagers.teamManagersMap[transaction.season]?.[
+                  transaction.rosters[origin]
+                ]?.team.name || ''
+              : '';
+          item = `${item} <i class="material-icons tradeIcon">arrow_forward</i> ${fromTeam}`;
+        }
+
+        details[i].push(item);
+      }
+    }
+
+    return details
+      .map((list, ix) => {
+        if (!list.length) return null;
+        const teamName =
+          leagueTeamManagers.teamManagersMap[transaction.season]?.[
+            transaction.rosters[ix]
+          ]?.team.name;
+        return `${teamName}: ${list.join(', ')}`;
+      })
+      .filter(Boolean)
+      .join(' | ');
+  };
+</script>
+
+<tr class={transaction.type}>
+  <td>{transaction.date}</td>
+  <td>{getTeams()}</td>
+  <td>{transaction.type}</td>
+  <td>{getBid()}</td>
+  <td>{@html getDetails()}</td>
+</tr>
+
+<style>
+  td {
+    padding: 0.5rem 0.3rem;
+    border-bottom: 1px solid var(--ddd);
+    vertical-align: top;
+  }
+
+  tr.trade td {
+    background: linear-gradient(90deg, var(--fff), var(--headerPrimary));
+  }
+
+  tr.waiver td {
+    background: linear-gradient(90deg, var(--fff), var(--waiverAdd));
+  }
+
+  .addIcon {
+    color: #00ceb8;
+    font-size: 1rem;
+    vertical-align: middle;
+  }
+
+  .dropIcon {
+    color: #ff2a6d;
+    font-size: 1rem;
+    vertical-align: middle;
+  }
+
+  .tradeIcon {
+    color: var(--blueTwo);
+    font-size: 1rem;
+    vertical-align: middle;
+  }
+</style>

--- a/src/lib/Transactions/TransactionsPage.svelte
+++ b/src/lib/Transactions/TransactionsPage.svelte
@@ -1,18 +1,76 @@
 <script>
 	import Textfield from '@smui/textfield';
   	import Icon from '@smui/textfield/icon';
-	import TradeTransaction from './TradeTransaction.svelte';
-	import Button, { Label } from '@smui/button';
-	import IconButton from '@smui/icon-button';
-	import Pagination from '../Pagination.svelte';
+        import Button, { Label } from '@smui/button';
+        import IconButton from '@smui/icon-button';
+        import Pagination from '../Pagination.svelte';
+        import TransactionRow from './TransactionRow.svelte';
 	import { match } from 'fuzzyjs';
 	import { goto } from '$app/navigation';
-	import { getLeagueTransactions, loadPlayers } from '$lib/utils/helper';
-	import WaiverTransaction from './WaiverTransaction.svelte';
+        import { getLeagueTransactions, loadPlayers } from '$lib/utils/helper';
 
-	export let show, playersInfo, query, queryPage, transactions, stale, perPage, postUpdate=false, leagueTeamManagers;
-	const oldQuery = query;
-	let page = queryPage || 0;
+       export let show, playersInfo, query, season, queryPage, transactions, stale, perPage, postUpdate=false, leagueTeamManagers;
+       const seasons = Object.keys(leagueTeamManagers.teamManagersMap).map(Number).sort((a,b) => b - a);
+       let teamFilter = 'all';
+       let minBid = '';
+       let maxBid = '';
+       $: teams = (() => {
+               if(season === 'all') {
+                       const names = new Set();
+                       for(const yr in leagueTeamManagers.teamManagersMap) {
+                               for(const rosterID in leagueTeamManagers.teamManagersMap[yr]) {
+                                       names.add(leagueTeamManagers.teamManagersMap[yr][rosterID].team.name);
+                               }
+                       }
+                       return Array.from(names).sort();
+               }
+               return Object.values(leagueTeamManagers.teamManagersMap[season]).map(t => t.team.name);
+       })();
+       const oldQuery = query;
+        let page = queryPage || 0;
+
+       let sortKey = 'date';
+       let sortDir = 'desc';
+
+       const sortArrow = (key) => {
+               if(sortKey !== key) return '';
+               return sortDir === 'asc' ? 'north' : 'south';
+       };
+
+       const getBid = (t) => {
+               if(t.type !== 'waiver') return 0;
+               for(const mv of t.moves) {
+                       for(const col of mv) {
+                               if(col?.bid) return col.bid;
+                       }
+               }
+               return 0;
+       };
+
+       const sortTransactions = (a, b) => {
+               let res = 0;
+               if(sortKey === 'date') {
+                       res = new Date(a.date) - new Date(b.date);
+               } else if(sortKey === 'team') {
+                       const ta = leagueTeamManagers.teamManagersMap[a.season]?.[a.rosters[0]]?.team.name || '';
+                       const tb = leagueTeamManagers.teamManagersMap[b.season]?.[b.rosters[0]]?.team.name || '';
+                       res = ta.localeCompare(tb);
+               } else if(sortKey === 'bid') {
+                       res = getBid(a) - getBid(b);
+               } else if(sortKey === 'type') {
+                       res = a.type.localeCompare(b.type);
+               }
+               return sortDir === 'asc' ? res : -res;
+       };
+
+       const setSort = (key) => {
+               if(sortKey === key) {
+                       sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+               } else {
+                       sortKey = key;
+                       sortDir = 'asc';
+               }
+       };
 
 	const refreshTransactions = async () => {
 		const newTransactions = await getLeagueTransactions(false, true);
@@ -37,46 +95,76 @@
 	// filtered subset based on search
 	let subsetTransactions = [];
 
-	let totalTransactions = 0;
+       let totalTransactions = 0;
 
-	const setFilter = (filterBy, transactions) => {
-		if(filterBy == "both") {
-			return transactions;
-		} else {
-			return transactions.filter( transaction => transaction.type == filterBy);
-		}
-	}
+       const filterSeason = (s, txs) => {
+               if(s === 'all') return txs;
+               return txs.filter(t => t.season == s);
+       };
 
-	// filtered subset based on filter
-	$: filteredTransactions = setFilter(show, transactions);
+       const filterType = (filterBy, txs) => {
+               if(filterBy == 'both') return txs;
+               return txs.filter(t => t.type == filterBy);
+       };
 
-	const setQuery = (query, filteredTransactions) => {
-		if(!filteredTransactions) {
-			return [];
-		}
-		if(query && query.trim() != "") {
-			subsetTransactions = filteredTransactions.filter( transaction => checkForQuery(transaction));
-			totalTransactions = subsetTransactions.length;
-		} else {
-			subsetTransactions = filteredTransactions;
-			totalTransactions = subsetTransactions.length;
-		}
+       const filterTeam = (team, txs) => {
+               if(team === 'all') return txs;
+               return txs.filter(t => t.rosters.some(r => {
+                       const tm = leagueTeamManagers.teamManagersMap[t.season]?.[r];
+                       return tm && tm.team.name === team;
+               }));
+       };
+
+       const filterBid = (min, max, txs) => {
+               return txs.filter(t => {
+                       if(t.type !== 'waiver') return true;
+                       let bid = 0;
+                       for(const mv of t.moves) {
+                               for(const col of mv) {
+                                       if(col?.bid) { bid = col.bid; break; }
+                               }
+                               if(bid) break;
+                       }
+                       if(min !== '' && bid < min) return false;
+                       if(max !== '' && bid > max) return false;
+                       return true;
+               });
+       };
+
+       // filtered subset based on filter
+       $: seasonTransactions = filterSeason(season, transactions);
+       $: typeTransactions = filterType(show, seasonTransactions);
+       $: teamTransactions = filterTeam(teamFilter, typeTransactions);
+       $: filteredTransactions = filterBid(minBid, maxBid, teamTransactions);
+       $: sortedTransactions = [...filteredTransactions].sort(sortTransactions);
+
+        const setQuery = (query, list) => {
+                if(!list) {
+                        return [];
+                }
+                if(query && query.trim() != "") {
+                        subsetTransactions = list.filter( transaction => checkForQuery(transaction));
+                        totalTransactions = subsetTransactions.length;
+                } else {
+                        subsetTransactions = list;
+                        totalTransactions = subsetTransactions.length;
+                }
 
 		const start = page * perPage;
 		const end = (page + 1) * perPage;
 		return subsetTransactions.slice(start, end);
 	}
-	$: displayTransactions = setQuery(query, filteredTransactions);
+        $: displayTransactions = setQuery(query, sortedTransactions);
 
 	const changePage = (dest, pageChange = false) => {
 		if(queryPage == dest && pageChange) return;
 		page = dest;
-		if(dest > (filteredTransactions.length / perPage) || dest < 0) {
-			page = 0;
-		}
-		displayTransactions = setQuery(query, filteredTransactions);
+                if(dest > (sortedTransactions.length / perPage) || dest < 0) {
+                        page = 0;
+                }
+                displayTransactions = setQuery(query, sortedTransactions);
 		if(postUpdate) {
-            goto(`/transactions?show=${show}&query=${query}&page=${page+1}`, {noscroll: true,  keepfocus: true});
+           goto(`/transactions?show=${show}&query=${query}&page=${page+1}&season=${season}`, {noscroll: true,  keepfocus: true});
 		}
 	}
 
@@ -97,7 +185,7 @@
 		if(query.trim() == oldQuery) return;
 		page = 0;
 		if(postUpdate) {
-            const dest = `/transactions?show=${show}&query=${query.trim()}&page=${page+1}`;
+           const dest = `/transactions?show=${show}&query=${query.trim()}&page=${page+1}&season=${season}`;
             debounce(dest);
 		}
 	}
@@ -105,7 +193,7 @@
 	const clearSearch = () => {
 		query = "";
 		if(postUpdate) {
-			goto(`/transactions?show=${show}&query=&page=${page+1}`, {noscroll: true,  keepfocus: true});
+                       goto(`/transactions?show=${show}&query=&page=${page+1}&season=${season}`, {noscroll: true,  keepfocus: true});
 		}
 	}
 	
@@ -117,20 +205,36 @@
 		}
 	}
 
-	const checkForQuery = (transaction) => {
-		const moves = transaction.moves;
-		for(const move of moves) {
-			for(const col of move) {
-				if(!col?.player) continue;
-				return checkMatch(query, `${players[col.player].fn} ${players[col.player].ln}`);
-			}
-		}
-		return false;
-	}
+       const checkForQuery = (transaction) => {
+               const moves = transaction.moves;
+               for(const move of moves) {
+                       for(const col of move) {
+                               if(!col?.player) continue;
+                               if(checkMatch(query, `${players[col.player].fn} ${players[col.player].ln}`)) {
+                                       return true;
+                               }
+                       }
+               }
+               for(const roster of transaction.rosters) {
+                       const team = leagueTeamManagers.teamManagersMap[transaction.season]?.[roster];
+                       if(team) {
+                               if(checkMatch(query, team.team.name)) {
+                                       return true;
+                               }
+                               for(const managerID of team.managers) {
+                                       const name = leagueTeamManagers.users[managerID]?.display_name;
+                                       if(name && checkMatch(query, name)) {
+                                               return true;
+                                       }
+                               }
+                       }
+               }
+               return false;
+       }
 
 	$: changePage(page, true);
 
-	$: setQuery(query);
+       $: setQuery(query, sortedTransactions);
 
     let el;
 
@@ -144,14 +248,14 @@
 </script>
 
 <style>
-	.transactionsParent {
-		display: flex;
-		flex-wrap: wrap;
-		position: relative;
-		width: 100%;
-		z-index: 1;
-		overflow-y: hidden;
-	}
+        .transactionsParent {
+                display: flex;
+                flex-direction: column;
+                position: relative;
+                width: 100%;
+                z-index: 1;
+                overflow-y: hidden;
+        }
 
     @media (max-width: 1000px) {
     }
@@ -170,17 +274,51 @@
 		margin: 30px auto 16px;
 	}
 
-	.buttons {
-		margin: 40px auto 0;
-	}
+        .filterBar {
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: space-between;
+                align-items: center;
+                gap: 1rem;
+                margin: 20px auto;
+                width: 100%;
+        }
+
+        .buttons {
+                display: flex;
+                gap: 0.5rem;
+        }
+
+        .buttons :global(.smui-button) {
+                border-radius: 20px;
+                text-transform: none;
+        }
+
+        .seasonFilter select {
+                padding: 0.4rem 0.8rem;
+                border-radius: 20px;
+                border: 1px solid var(--blueTwo);
+                background: var(--fff);
+        }
+
+        .teamFilter select,
+        .bidFilter input {
+                padding: 0.4rem 0.6rem;
+                border-radius: 20px;
+                border: 1px solid var(--blueTwo);
+                background: var(--fff);
+        }
+
+        .bidFilter {
+                display: flex;
+                gap: 0.3rem;
+                align-items: center;
+        }
 
 	:global(.disabled) {
 		pointer-events: none;
 	}
 
-	.invis-buttons {
-		display: none !important;
-	}
 
 	.searchContainer {
 		width: 100%;
@@ -193,65 +331,87 @@
 		display: inline-block;
 	}
 	
-	.empty {
-		width: 100%;
-		font-style: italic;
-		text-align: center;
-		color: #999;
-	}
+        .empty {
+                width: 100%;
+                font-style: italic;
+                text-align: center;
+                color: #999;
+        }
+
+        .txTable {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 1rem;
+        }
+
+        .txTable th {
+                text-align: left;
+                cursor: pointer;
+                padding: 0.5rem;
+                border-bottom: 2px solid var(--blueTwo);
+                }
+
+        .sortIcon {
+                font-size: 1rem;
+                vertical-align: middle;
+        }
+
+        .txTable tbody tr:nth-child(odd) {
+                background-color: var(--eee);
+        }
 </style>
 
 <div class="transactionsParent">
-	<div class="buttons {show == "trade" ? "" : "invis-buttons"}">
-		<Button class="{show == "trade" ? "disabled" : ""}" color="primary" onclick={() => setShow("trade")} variant="{show == "trade" ? "raised" : "outlined"}" touch>
-			<Label>Trades</Label>
-		</Button>
-		<Button class="{show == "waiver" ? "disabled" : ""}" color="primary" onclick={() => setShow("waiver")} variant="{show == "waiver" ? "raised" : "outlined"}" touch>
-			<Label>Waivers</Label>
-		</Button>
-		<Button class="{show == "both" ? "disabled" : ""}" color="primary" onclick={() => setShow("both")} variant="{show == "both" ? "raised" : "outlined"}" touch>
-			<Label>Both</Label>
-		</Button>
-	</div>
-	<div class="buttons {show == "waiver" ? "" : "invis-buttons"}">
-		<Button class="{show == "trade" ? "disabled" : ""}" color="primary" onclick={() => setShow("trade")} variant="{show == "trade" ? "raised" : "outlined"}" touch>
-			<Label>Trades</Label>
-		</Button>
-		<Button class="{show == "waiver" ? "disabled" : ""}" color="primary" onclick={() => setShow("waiver")} variant="{show == "waiver" ? "raised" : "outlined"}" touch>
-			<Label>Waivers</Label>
-		</Button>
-		<Button class="{show == "both" ? "disabled" : ""}" color="primary" onclick={() => setShow("both")} variant="{show == "both" ? "raised" : "outlined"}" touch>
-			<Label>Both</Label>
-		</Button>
-	</div>
-	<div class="buttons {show == "both" ? "" : "invis-buttons"}">
-		<Button class="{show == "trade" ? "disabled" : ""}" color="primary" onclick={() => setShow("trade")} variant="{show == "trade" ? "raised" : "outlined"}" touch>
-			<Label>Trades</Label>
-		</Button>
-		<Button class="{show == "waiver" ? "disabled" : ""}" color="primary" onclick={() => setShow("waiver")} variant="{show == "waiver" ? "raised" : "outlined"}" touch>
-			<Label>Waivers</Label>
-		</Button>
-		<Button class="{show == "both" ? "disabled" : ""}" color="primary" onclick={() => setShow("both")} variant="{show == "both" ? "raised" : "outlined"}" touch>
-			<Label>Both</Label>
-		</Button>
-	</div>
-	<div class="searchContainer">
-		<span class="clearPlaceholder" />
-		<Textfield
-			class="shaped-outlined"
-			variant="outlined"
-			bind:value={query}
-			label="Search for a player..."
-			on:input={() => search()}
-		>
-			<Icon class="material-icons" slot="leadingIcon">search</Icon>
-		</Textfield>
-		{#if query.length > 0}
-			  <IconButton class="material-icons" onclick={() => clearSearch()}>clear</IconButton>
-		{:else}
-			<span class="clearPlaceholder" />
-		{/if}
-	</div>
+        <div class="filterBar">
+                <div class="buttons">
+                        <Button class="{show == 'trade' ? 'disabled' : ''}" color="primary" onclick={() => setShow('trade')} variant="{show == 'trade' ? 'raised' : 'outlined'}" touch>
+                                <Label>Trades</Label>
+                        </Button>
+                        <Button class="{show == 'waiver' ? 'disabled' : ''}" color="primary" onclick={() => setShow('waiver')} variant="{show == 'waiver' ? 'raised' : 'outlined'}" touch>
+                                <Label>Waivers</Label>
+                        </Button>
+                        <Button class="{show == 'both' ? 'disabled' : ''}" color="primary" onclick={() => setShow('both')} variant="{show == 'both' ? 'raised' : 'outlined'}" touch>
+                                <Label>Both</Label>
+                        </Button>
+                </div>
+                <div class="seasonFilter">
+                        <select bind:value={season} on:change={() => {teamFilter='all';changePage(0);}}>
+                                <option value="all">All Seasons</option>
+                                {#each seasons as yr}
+                                        <option value={yr}>{yr}</option>
+                                {/each}
+                        </select>
+                </div>
+                <div class="teamFilter">
+                        <select bind:value={teamFilter} on:change={() => changePage(0)}>
+                                <option value="all">All Teams</option>
+                                {#each teams as teamName}
+                                        <option value={teamName}>{teamName}</option>
+                                {/each}
+                        </select>
+                </div>
+                <div class="bidFilter">
+                        <input type="number" min="0" placeholder="Min Bid" bind:value={minBid} />
+                        <input type="number" min="0" placeholder="Max Bid" bind:value={maxBid} />
+                </div>
+                <div class="searchContainer">
+                        <span class="clearPlaceholder" />
+                        <Textfield
+                                class="shaped-outlined"
+                                variant="outlined"
+                                bind:value={query}
+                                label="Search for a player or manager..."
+                                on:input={() => search()}
+                        >
+                                <Icon class="material-icons" slot="leadingIcon">search</Icon>
+                        </Textfield>
+                        {#if query.length > 0}
+                                  <IconButton class="material-icons" onclick={() => clearSearch()}>clear</IconButton>
+                        {:else}
+                                <span class="clearPlaceholder" />
+                        {/if}
+                </div>
+        </div>
 
 	<div class="transactions" bind:this={el}>
 		{#if show == "both"}
@@ -265,17 +425,32 @@
 			<h5>Recent Waivers</h5>
 		{/if}
 
-		<Pagination {perPage} total={totalTransactions} bind:page={page} target={top} scroll={false} />
-		<div class="transactions-child">
-			{#each displayTransactions as transaction (transaction.id)}
-                {#if transaction.type == "waiver"}
-				    <WaiverTransaction {players} {transaction} {leagueTeamManagers} />
-                {:else}
-				    <TradeTransaction {players} {transaction} {leagueTeamManagers} />
-                {/if}
-			{/each}
-		</div>
-		<Pagination {perPage} total={totalTransactions} bind:page={page} target={top} scroll={true} />
+                <Pagination {perPage} total={totalTransactions} bind:page={page} target={top} scroll={false} />
+                <table class="txTable">
+                        <thead>
+                                <tr>
+                                        <th on:click={() => setSort('date')}>
+                                                Date <i class="material-icons sortIcon">{sortArrow('date')}</i>
+                                        </th>
+                                        <th on:click={() => setSort('team')}>
+                                                Team(s) <i class="material-icons sortIcon">{sortArrow('team')}</i>
+                                        </th>
+                                        <th on:click={() => setSort('type')}>
+                                                Type <i class="material-icons sortIcon">{sortArrow('type')}</i>
+                                        </th>
+                                        <th on:click={() => setSort('bid')}>
+                                                Bid <i class="material-icons sortIcon">{sortArrow('bid')}</i>
+                                        </th>
+                                        <th>Details</th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                        {#each displayTransactions as transaction (transaction.id)}
+                                <TransactionRow {transaction} {players} {leagueTeamManagers} />
+                        {/each}
+                        </tbody>
+                </table>
+                <Pagination {perPage} total={totalTransactions} bind:page={page} target={top} scroll={true} />
 
 	</div>
 
@@ -289,3 +464,4 @@
 		{/if}
 	{/if}
 </div>
+

--- a/src/routes/transactions/+page.js
+++ b/src/routes/transactions/+page.js
@@ -1,35 +1,44 @@
-import { getLeagueTransactions, loadPlayers, getLeagueTeamManagers } from '$lib/utils/helper';
+import {
+  getLeagueTransactions,
+  loadPlayers,
+  getLeagueTeamManagers,
+} from "$lib/utils/helper";
 
 export async function load({ url, fetch }) {
-    const show = url?.searchParams?.get('show');
-    const query = url?.searchParams?.get('query');
-    const curPage = url?.searchParams?.get('page');
+  const show = url?.searchParams?.get("show");
+  const query = url?.searchParams?.get("query");
+  const curPage = url?.searchParams?.get("page");
+  const seasonParam = url?.searchParams?.get("season");
 
-    const transactionsData = getLeagueTransactions(false);
-    const leagueTeamManagersData = getLeagueTeamManagers();
+  const transactionsData = getLeagueTransactions(false);
+  const leagueTeamManagersData = getLeagueTeamManagers();
 
-    const playersData = loadPlayers(fetch);
+  const playersData = loadPlayers(fetch);
 
-    const bannedValued = [
-        'undefined',
-    ]
+  const bannedValued = ["undefined"];
 
-    const props = {
-        show: "both",
-        query: "",
-        playersData,
-        transactionsData,
-        leagueTeamManagersData,
-        page: 0,
-    }
-    if(show && (show == "trade" || show == "waiver" || show == "both")) {
-        props.show = show;
-    }
-    if(query && !bannedValued.includes(query)) {
-        props.query = query;
-    }
-    if(curPage && !isNaN(curPage)) {
-        props.page = parseInt(curPage) - 1;
-    }
-    return props;
+  const props = {
+    show: "both",
+    query: "",
+    season: "all",
+    playersData,
+    transactionsData,
+    leagueTeamManagersData,
+    page: 0,
+  };
+  if (show && (show == "trade" || show == "waiver" || show == "both")) {
+    props.show = show;
+  }
+  if (query && !bannedValued.includes(query)) {
+    props.query = query;
+  }
+  if (curPage && !isNaN(curPage)) {
+    props.page = parseInt(curPage) - 1;
+  }
+  if (seasonParam && !isNaN(seasonParam)) {
+    props.season = parseInt(seasonParam);
+  } else if (seasonParam === "all") {
+    props.season = "all";
+  }
+  return props;
 }

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -4,7 +4,7 @@
     import { waitForAll } from '$lib/utils/helper';
 
     export let data;
-    const {show, query, page, playersData, transactionsData, leagueTeamManagersData} = data;
+    const {show, query, season, page, playersData, transactionsData, leagueTeamManagersData} = data;
 
 	const perPage = 10;
 </script>
@@ -37,7 +37,7 @@
             <LinearProgress indeterminate />
         </div>
     {:then [{transactions, currentTeams, stale}, playersInfo, leagueTeamManagers]}
-        <TransactionsPage {playersInfo} {stale} {transactions} {currentTeams} {show} {query} queryPage={page} {perPage} postUpdate={true} {leagueTeamManagers} />
+        <TransactionsPage {playersInfo} {stale} {transactions} {currentTeams} {show} {query} {season} queryPage={page} {perPage} postUpdate={true} {leagueTeamManagers} />
     {:catch error}
         <p class="center">Something went wrong: {error.message}</p>
     {/await}


### PR DESCRIPTION
## Summary
- modernize transaction filter buttons and layout
- allow season selection and manager search
- add team filtering and waiver bid range filters
- wire season state through page loader
- display transactions in sortable table for easier browsing
- add colored icons and trade breakdown details
- sortable columns now show arrow indicators
- rows use subtle gradients by transaction type

## Testing
- `npm run lint` *(fails: Code style issues found)*


------
https://chatgpt.com/codex/tasks/task_e_685ce492f7808323bd739ff8ab561ec7