### PR TITLE
Add player detail page

### DIFF
--- a/src/lib/Players/Player.svelte
+++ b/src/lib/Players/Player.svelte
@@ -1,0 +1,107 @@
+<script>
+    import TransactionsPage from '../Transactions/TransactionsPage.svelte';
+    import { getTeamFromTeamManagers } from '../utils/helperFunctions/universalFunctions';
+
+    export let playerID;
+    export let playersInfo;
+    export let transactionsInfo;
+    export let leagueTeamManagers;
+
+    const players = playersInfo.players;
+    const player = players[playerID];
+
+    $: playerTransactions = transactionsInfo.transactions.filter(t => {
+        for (const move of t.moves) {
+            for (const cell of move) {
+                if (cell && cell.player == playerID) return true;
+            }
+        }
+        return false;
+    });
+
+    $: historyMap = {};
+    for (const t of playerTransactions) {
+        if (!historyMap[t.season]) historyMap[t.season] = new Set();
+        for (const rid of t.rosters) {
+            historyMap[t.season].add(rid);
+        }
+    }
+    $: teamHistory = Object.entries(historyMap).map(([year, set]) => ({ year, rosters: Array.from(set) })).sort((a,b) => b.year - a.year);
+
+    $: weeklyProjections = [];
+    if (player && player.wi) {
+        for (const w in player.wi) {
+            weeklyProjections.push({ week: +w, opp: player.wi[w].o, proj: player.wi[w].p });
+        }
+        weeklyProjections.sort((a,b) => a.week - b.week);
+    }
+</script>
+
+<style>
+    .playerInfo {
+        text-align: center;
+        margin: 2em 0;
+    }
+    .history {
+        margin: 2em auto;
+        width: 90%;
+        max-width: 600px;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+    th, td {
+        padding: 4px 6px;
+        border: 1px solid var(--ddd);
+        text-align: center;
+    }
+</style>
+
+{#if player}
+<div class="playerInfo">
+    <h2>{player.fn} {player.ln}</h2>
+    <p>{player.pos}{player.t ? ` - ${player.t}` : ''}</p>
+</div>
+
+{#if teamHistory.length}
+<div class="history">
+    <h3>Teams History</h3>
+    <ul>
+        {#each teamHistory as entry}
+            <li><b>{entry.year}:</b>
+                {#each entry.rosters as rid, idx}
+                    {#if idx > 0}, {/if}
+                    {getTeamFromTeamManagers(leagueTeamManagers, rid, entry.year).name}
+                {/each}
+            </li>
+        {/each}
+    </ul>
+</div>
+{/if}
+
+{#if weeklyProjections.length}
+<div class="history">
+    <h3>Weekly Projections</h3>
+    <table>
+        <thead><tr><th>Week</th><th>Opp</th><th>PPR</th></tr></thead>
+        <tbody>
+            {#each weeklyProjections as row}
+                <tr><td>{row.week}</td><td>{row.opp}</td><td>{row.proj}</td></tr>
+            {/each}
+        </tbody>
+    </table>
+</div>
+{/if}
+
+<h3 style="text-align:center">Transaction History</h3>
+<div class="history">
+    {#if playerTransactions.length}
+        <TransactionsPage {playersInfo} transactions={playerTransactions} {leagueTeamManagers} show="both" query="" page={0} perPage={5}/>
+    {:else}
+        <p>No transactions for this player.</p>
+    {/if}
+</div>
+{:else}
+<p class="playerInfo">Player not found.</p>
+{/if}

--- a/src/lib/Rosters/Roster.svelte
+++ b/src/lib/Rosters/Roster.svelte
@@ -54,8 +54,9 @@
 				default:
 					break;
 			}
-			player = {
-				name: `${passedPlayers[singlePlayer].fn} ${passedPlayers[singlePlayer].ln}${injury ? `<span class="injury ${injury}">${injury}</span>` : ""}`,
+                        player = {
+                                id: singlePlayer,
+                                name: `${passedPlayers[singlePlayer].fn} ${passedPlayers[singlePlayer].ln}${injury ? `<span class="injury ${injury}">${injury}</span>` : ""}`,
                 nickname: roster.metadata && roster.metadata[`p_nick_${singlePlayer}`] ? roster.metadata[`p_nick_${singlePlayer}`] : null,
 				poss: passedPlayers[singlePlayer].pos,
 				team: passedPlayers[singlePlayer].t,

--- a/src/lib/Rosters/RosterRow.svelte
+++ b/src/lib/Rosters/RosterRow.svelte
@@ -1,5 +1,6 @@
 <script>
-	import { Row, Cell } from '@smui/data-table';
+import { Row, Cell } from '@smui/data-table';
+import { gotoPlayer } from '$lib/utils/helper';
 	
 	export let player;
 
@@ -214,17 +215,17 @@
 
 <Row>
 	<Cell class="slot playerCell"><span class="pos {playerSLotClass}">{playerSlot}</span></Cell>
-	{#if player.avatar}
-		<Cell class="avatar playerCell">
-            <div class="playerAvatar" style="{player.avatar}">
+        {#if player.avatar}
+                <Cell class="avatar playerCell" on:click={() => gotoPlayer(player.id)}>
+            <div class="playerAvatar clickable" style="{player.avatar}">
                 {#if player.team && player.poss != "DEF"}
                     <img src="https://sleepercdn.com/images/team_logos/nfl/{player.team.toLowerCase()}.png" class="teamLogo" alt="team logo"/>
                 {/if}
             </div>
         </Cell>
 	{/if}
-	<Cell class="playerCell nameCell" colspan={player.name != "Empty" ? 1 : 3}>
-        <div class="info">
+        <Cell class="playerCell nameCell" colspan={player.name != "Empty" ? 1 : 3}>
+        <div class="info clickable" on:click={() => gotoPlayer(player.id)}>
             <!-- name -->
             {@html player.name}
             <!-- name -->

--- a/src/lib/Transactions/TransactionMove.svelte
+++ b/src/lib/Transactions/TransactionMove.svelte
@@ -1,5 +1,6 @@
 <script>
-	import { getTeamFromTeamManagers } from '$lib/utils/helperFunctions/universalFunctions';
+import { getTeamFromTeamManagers } from '$lib/utils/helperFunctions/universalFunctions';
+import { gotoPlayer } from '$lib/utils/helper';
 
 	export let move, leagueTeamManagers, players, season;
 
@@ -244,7 +245,7 @@
                 <div class="line lineL {checkL(cell, ix) ? "hidden" : ""}" />
                 <div class="line lineR {checkR(cell, ix) ? "hidden" : ""}" />
                 {#if cell && cell.player}
-                    <div class="playerSlot">
+                    <div class="playerSlot clickable" on:click={() => gotoPlayer(cell.player)}>
                             <div class="tradeSlot playerAvatar" style="border-color: var(--{players[cell.player].pos}); {getAvatar(players[cell.player].pos, cell.player)}">
                                 <i class="indicator material-icons" aria-hidden="true">add_circle</i>
                             </div>

--- a/src/lib/components.js
+++ b/src/lib/components.js
@@ -1,43 +1,45 @@
-import Nav from './Nav/index.svelte';
-import Footer from './Footer.svelte';
-import News from './News/index.svelte';
-import Resources from './Resources.svelte';
-import Awards from './Awards/Awards.svelte';
-import Rosters from './Rosters/Rosters.svelte';
-import Rivalry from './Rivalry/index.svelte';
-import Transactions from './Transactions/Transactions.svelte';
-import TransactionsPage from './Transactions/TransactionsPage.svelte';
-import MatchupsAndBrackets from './Matchups/MatchupsAndBrackets.svelte';
-import Pagination from './Pagination.svelte';
-import Drafts from './Drafts/index.svelte';
-import Records from './Records/index.svelte';
-import Manager from './Managers/Manager.svelte';
-import AllManagers from './Managers/AllManagers.svelte';
-import PowerRankings from './PowerRankings/index.svelte';
-import HomePost from './BlogPosts/HomePost.svelte';
-import FullPost from './BlogPosts/FullPost.svelte';
-import Posts from './BlogPosts/Posts.svelte';
-import Standings from './Standings/index.svelte';
+import Nav from "./Nav/index.svelte";
+import Footer from "./Footer.svelte";
+import News from "./News/index.svelte";
+import Resources from "./Resources.svelte";
+import Awards from "./Awards/Awards.svelte";
+import Rosters from "./Rosters/Rosters.svelte";
+import Rivalry from "./Rivalry/index.svelte";
+import Transactions from "./Transactions/Transactions.svelte";
+import TransactionsPage from "./Transactions/TransactionsPage.svelte";
+import MatchupsAndBrackets from "./Matchups/MatchupsAndBrackets.svelte";
+import Pagination from "./Pagination.svelte";
+import Drafts from "./Drafts/index.svelte";
+import Records from "./Records/index.svelte";
+import Manager from "./Managers/Manager.svelte";
+import AllManagers from "./Managers/AllManagers.svelte";
+import PowerRankings from "./PowerRankings/index.svelte";
+import HomePost from "./BlogPosts/HomePost.svelte";
+import FullPost from "./BlogPosts/FullPost.svelte";
+import Posts from "./BlogPosts/Posts.svelte";
+import Standings from "./Standings/index.svelte";
+import Player from "./Players/Player.svelte";
 
 export {
-    Nav,
-    Footer,
-    Awards,
-    Rosters,
-    Rivalry,
-    Transactions,
-    TransactionsPage,
-    News,
-    Resources,
-    MatchupsAndBrackets,
-    Pagination,
-    Drafts,
-    Records,
-    Manager,
-    AllManagers,
-    PowerRankings,
-    HomePost,
-    Posts,
-    FullPost,
-    Standings,
+  Nav,
+  Footer,
+  Awards,
+  Rosters,
+  Rivalry,
+  Transactions,
+  TransactionsPage,
+  News,
+  Resources,
+  MatchupsAndBrackets,
+  Pagination,
+  Drafts,
+  Records,
+  Manager,
+  AllManagers,
+  PowerRankings,
+  HomePost,
+  Posts,
+  FullPost,
+  Standings,
+  Player,
 };

--- a/src/lib/utils/helper.js
+++ b/src/lib/utils/helper.js
@@ -1,57 +1,82 @@
-import {getLeagueData} from './helperFunctions/leagueData';
-import {dues, leagueID, leagueName, dynasty, managers, homepageText, enableBlog} from './leagueInfo';
-import {getLeagueTransactions} from './helperFunctions/leagueTransactions';
-import {getNflState} from './helperFunctions/nflState';
-import {getLeagueRosters} from './helperFunctions/leagueRosters';
-import {getLeagueTeamManagers} from './helperFunctions/leagueTeamManagers';
-import {getLeagueMatchups} from './helperFunctions/leagueMatchups'
-import {getRivalryMatchups} from './helperFunctions/rivalryMatchups'
-import {getNews, stringDate} from './helperFunctions/news';
-import {loadPlayers} from './helperFunctions/players';
-import { waitForAll } from './helperFunctions/multiPromise';
-import { getUpcomingDraft, getPreviousDrafts } from './helperFunctions/leagueDrafts'
-import { getLeagueRecords } from './helperFunctions/leagueRecords'
-import { getAwards } from './helperFunctions/leagueAwards'
-import { cleanName, round, generateGraph, getTeamFromTeamManagers, gotoManager, getAuthor, parseDate, getAvatar } from './helperFunctions/universalFunctions';
-import { predictScores } from './helperFunctions/predictOptimalScore';
-import { getBrackets } from './helperFunctions/leagueBrackets';
-import { getBlogPosts, generateParagraph } from './helperFunctions/getBlogPosts';
-import { getLeagueStandings } from './helperFunctions/leagueStandings';
+import { getLeagueData } from "./helperFunctions/leagueData";
+import {
+  dues,
+  leagueID,
+  leagueName,
+  dynasty,
+  managers,
+  homepageText,
+  enableBlog,
+} from "./leagueInfo";
+import { getLeagueTransactions } from "./helperFunctions/leagueTransactions";
+import { getNflState } from "./helperFunctions/nflState";
+import { getLeagueRosters } from "./helperFunctions/leagueRosters";
+import { getLeagueTeamManagers } from "./helperFunctions/leagueTeamManagers";
+import { getLeagueMatchups } from "./helperFunctions/leagueMatchups";
+import { getRivalryMatchups } from "./helperFunctions/rivalryMatchups";
+import { getNews, stringDate } from "./helperFunctions/news";
+import { loadPlayers } from "./helperFunctions/players";
+import { waitForAll } from "./helperFunctions/multiPromise";
+import {
+  getUpcomingDraft,
+  getPreviousDrafts,
+} from "./helperFunctions/leagueDrafts";
+import { getLeagueRecords } from "./helperFunctions/leagueRecords";
+import { getAwards } from "./helperFunctions/leagueAwards";
+import {
+  cleanName,
+  round,
+  generateGraph,
+  getTeamFromTeamManagers,
+  gotoManager,
+  gotoPlayer,
+  getAuthor,
+  parseDate,
+  getAvatar,
+} from "./helperFunctions/universalFunctions";
+import { predictScores } from "./helperFunctions/predictOptimalScore";
+import { getBrackets } from "./helperFunctions/leagueBrackets";
+import {
+  getBlogPosts,
+  generateParagraph,
+} from "./helperFunctions/getBlogPosts";
+import { getLeagueStandings } from "./helperFunctions/leagueStandings";
 
 export {
-    enableBlog,
-    homepageText,
-    gotoManager,
-    managers,
-    getLeagueData,
-    getLeagueTransactions,
-    getNflState, 
-    getLeagueRosters,
-    getLeagueTeamManagers,
-    getLeagueMatchups,
-    getRivalryMatchups,
-    getNews,
-    loadPlayers,
-    waitForAll,
-    getUpcomingDraft,
-    getPreviousDrafts,
-    getLeagueRecords,
-    cleanName,
-    round,
-    dues,
-    leagueID,
-    leagueName,
-    dynasty,
-    getAwards,
-    stringDate,
-    getBrackets,
-    generateGraph,
-    getBlogPosts,
-    generateParagraph,
-    predictScores,
-    getLeagueStandings,
-    getAuthor,
-    parseDate,
-    getAvatar,
-    getTeamFromTeamManagers,
-}
+  enableBlog,
+  homepageText,
+  gotoManager,
+  managers,
+  getLeagueData,
+  getLeagueTransactions,
+  getNflState,
+  getLeagueRosters,
+  getLeagueTeamManagers,
+  getLeagueMatchups,
+  getRivalryMatchups,
+  getNews,
+  loadPlayers,
+  waitForAll,
+  getUpcomingDraft,
+  getPreviousDrafts,
+  getLeagueRecords,
+  cleanName,
+  round,
+  dues,
+  leagueID,
+  leagueName,
+  dynasty,
+  getAwards,
+  stringDate,
+  getBrackets,
+  generateGraph,
+  getBlogPosts,
+  generateParagraph,
+  predictScores,
+  getLeagueStandings,
+  getAuthor,
+  parseDate,
+  getAvatar,
+  getTeamFromTeamManagers,
+  gotoPlayer,
+};

--- a/src/lib/utils/helperFunctions/universalFunctions.js
+++ b/src/lib/utils/helperFunctions/universalFunctions.js
@@ -1,156 +1,183 @@
-import { managers as managersObj } from '$lib/utils/leagueInfo';
+import { managers as managersObj } from "$lib/utils/leagueInfo";
 import { goto } from "$app/navigation";
-import { stringDate } from './news';
+import { stringDate } from "./news";
 
-const QUESTION = 'managers/question.jpg';
+const QUESTION = "managers/question.jpg";
 
 export const cleanName = (name) => {
-    return name.replace('Team ', '').toLowerCase().replace(/[ ’'!"#$%&\\'()\*+,\-\.\/:;<=>?@\[\\\]\^_`{|}~']/g, "");
-}
+  return name
+    .replace("Team ", "")
+    .toLowerCase()
+    .replace(/[ ’'!"#$%&\\'()\*+,\-\.\/:;<=>?@\[\\\]\^_`{|}~']/g, "");
+};
 
 export const round = (num) => {
-    if(typeof(num) =="string") {
-        num = parseFloat(num)
-    }
-    return (Math.round((num + Number.EPSILON) * 100) / 100).toFixed(2);
-}
+  if (typeof num == "string") {
+    num = parseFloat(num);
+  }
+  return (Math.round((num + Number.EPSILON) * 100) / 100).toFixed(2);
+};
 
 const min = (stats, roundOverride, max) => {
-    const num = Math.min(...stats);
-    let minAnswer = Math.floor(num / roundOverride) * roundOverride;
-    if(max && num > 0) {
-        let i = 0;
-        while(minAnswer > 0 && (num - minAnswer) / (max - minAnswer) < .15) {
-            minAnswer -= roundOverride;
-            i++;
-            // prevent infinite loop, emergency exit
-            if(i > 100) {
-                break;
-            }
-        }
+  const num = Math.min(...stats);
+  let minAnswer = Math.floor(num / roundOverride) * roundOverride;
+  if (max && num > 0) {
+    let i = 0;
+    while (minAnswer > 0 && (num - minAnswer) / (max - minAnswer) < 0.15) {
+      minAnswer -= roundOverride;
+      i++;
+      // prevent infinite loop, emergency exit
+      if (i > 100) {
+        break;
+      }
     }
-    return minAnswer > 0 ? minAnswer : 0;
-}
+  }
+  return minAnswer > 0 ? minAnswer : 0;
+};
 
 const max = (stats, roundOverride) => {
-    const num = Math.max(...stats);
-    return Math.ceil(num / roundOverride) * roundOverride;
-}
+  const num = Math.max(...stats);
+  return Math.ceil(num / roundOverride) * roundOverride;
+};
 
-export const gotoManager = ({leagueTeamManagers, managerID, rosterID, year}) => {
-    if(!managersObj.length) return;
-    let managersIndex = -1;
+export const gotoManager = ({
+  leagueTeamManagers,
+  managerID,
+  rosterID,
+  year,
+}) => {
+  if (!managersObj.length) return;
+  let managersIndex = -1;
 
-    if(!year || year > leagueTeamManagers.currentSeason) {
-        year = leagueTeamManagers.currentSeason;
+  if (!year || year > leagueTeamManagers.currentSeason) {
+    year = leagueTeamManagers.currentSeason;
+  }
+
+  if (managerID) {
+    // modern approach
+    managersIndex = managersObj.findIndex((m) => m.managerID == managerID);
+
+    // support for league pages still using deprecated roster field
+    if (managersIndex < 0 && leagueTeamManagers.teamManagersMap[year] != null) {
+      for (const rID in leagueTeamManagers.teamManagersMap[year]) {
+        if (leagueTeamManagers.teamManagersMap[year][rID] == null) continue;
+        for (const mID of leagueTeamManagers.teamManagersMap[year][rID]
+          .managers) {
+          if (mID == managerID) {
+            managersIndex = managersObj.findIndex((m) => m.roster == rID);
+            goto(`/manager?manager=${managersIndex}`);
+            return;
+          }
+        }
+      }
+    }
+  } else if (rosterID) {
+    // check for matching managerID first
+    if (leagueTeamManagers.teamManagersMap[year] != null) {
+      for (const mID of leagueTeamManagers.teamManagersMap[year][rosterID]
+        .managers) {
+        managersIndex = managersObj.findIndex((m) => m.managerID == mID);
+        if (managersIndex > -1) {
+          goto(`/manager?manager=${managersIndex}`);
+          return;
+        }
+      }
     }
 
-    if(managerID) {
-        // modern approach
-        managersIndex = managersObj.findIndex(m => m.managerID == managerID);
+    // support for league pages still using deprecated roster field
+    managersIndex = managersObj.findIndex((m) => m.roster == rosterID);
+  }
 
-        // support for league pages still using deprecated roster field
-        if(managersIndex < 0 && leagueTeamManagers.teamManagersMap[year] != null) {
-            for(const rID in leagueTeamManagers.teamManagersMap[year]) {
-                if(leagueTeamManagers.teamManagersMap[year][rID] == null) continue;
-                for(const mID of leagueTeamManagers.teamManagersMap[year][rID].managers) {
-                    if(mID == managerID) {
-                        managersIndex =  managersObj.findIndex(m => m.roster == rID);
-                        goto(`/manager?manager=${managersIndex}`);
-                        return;
-                    }
-                }
-            }
-        }
-    } else if(rosterID) {
-        // check for matching managerID first
-        if(leagueTeamManagers.teamManagersMap[year] != null) {
-            for(const mID of leagueTeamManagers.teamManagersMap[year][rosterID].managers) {
-                managersIndex = managersObj.findIndex(m => m.managerID == mID);
-                if(managersIndex > -1) {
-                    goto(`/manager?manager=${managersIndex}`);
-                    return;
-                }
-            }
-        }
-        
-        // support for league pages still using deprecated roster field
-        managersIndex = managersObj.findIndex(m => m.roster == rosterID);
-    }
+  // if no manager exists for that roster, -1 will take you to the main managers page
+  goto(`/manager?manager=${managersIndex}`);
+};
 
-    // if no manager exists for that roster, -1 will take you to the main managers page
-    goto(`/manager?manager=${managersIndex}`);
-}
+export const gotoPlayer = (playerID) => {
+  if (!playerID) return;
+  goto(`/player?player=${playerID}`);
+};
 
 export const getAuthor = (leagueTeamManagers, author) => {
-    for(const userID in leagueTeamManagers.users) {
-        if(leagueTeamManagers.users[userID].user_name.toLowerCase() == author.toLowerCase()) {
-            return [`<a href="/manager?manager=${managersObj.findIndex(m => m.managerID == String(userID))}">${leagueTeamManagers.users[userID].display_name}</a>`, ]
-        }
+  for (const userID in leagueTeamManagers.users) {
+    if (
+      leagueTeamManagers.users[userID].user_name.toLowerCase() ==
+      author.toLowerCase()
+    ) {
+      return [
+        `<a href="/manager?manager=${managersObj.findIndex((m) => m.managerID == String(userID))}">${leagueTeamManagers.users[userID].display_name}</a>`,
+      ];
     }
-    return author;
-}
+  }
+  return author;
+};
 
 export const getAvatar = (leagueTeamManagers, author) => {
-    for(const uID in leagueTeamManagers.users) {
-        if(leagueTeamManagers.users[uID].user_name.toLowerCase() == author.toLowerCase()) {
-            return `https://sleepercdn.com/avatars/thumbs/${leagueTeamManagers.users[uID].avatar}`;
-        }
+  for (const uID in leagueTeamManagers.users) {
+    if (
+      leagueTeamManagers.users[uID].user_name.toLowerCase() ==
+      author.toLowerCase()
+    ) {
+      return `https://sleepercdn.com/avatars/thumbs/${leagueTeamManagers.users[uID].avatar}`;
     }
-    return QUESTION;
-}
+  }
+  return QUESTION;
+};
 
 export const parseDate = (rawDate) => {
-    const ts = Date.parse(rawDate);
-    const d = new Date(ts);
-    return stringDate(d);
-}
+  const ts = Date.parse(rawDate);
+  const d = new Date(ts);
+  return stringDate(d);
+};
 
-export const generateGraph = ({stats, x, stat, header, field, short, secondField = null}, year, roundOverride = 10, xMinOverride = null) => {
-    if(!stats) {
-        return null;
+export const generateGraph = (
+  { stats, x, stat, header, field, short, secondField = null },
+  year,
+  roundOverride = 10,
+  xMinOverride = null,
+) => {
+  if (!stats) {
+    return null;
+  }
+  const graph = {
+    stats: [],
+    secondStats: [],
+    managerIDs: [],
+    rosterIDs: [],
+    labels: { x, stat },
+    header,
+    xMin: 0,
+    xMax: 0,
+    short,
+    year,
+  };
+
+  const sortedStats = [...stats].sort((a, b) => b[field] - a[field]);
+
+  for (const indivStat of sortedStats) {
+    graph.stats.push(indivStat[field]);
+    if (secondField) {
+      graph.secondStats.push(indivStat[secondField]);
     }
-    const graph = {
-        stats: [],
-        secondStats: [],
-        managerIDs: [],
-        rosterIDs: [],
-        labels: {x, stat},
-        header,
-        xMin: 0,
-        xMax: 0,
-        short,
-        year
+    if (indivStat.managerID) {
+      graph.managerIDs.push(indivStat.managerID);
+      graph.rosterIDs.push(null);
+    } else if (indivStat.rosterID) {
+      graph.managerIDs.push(null);
+      graph.rosterIDs.push(indivStat.rosterID);
     }
+  }
 
-    const sortedStats = [...stats].sort((a, b) => b[field] - a[field]);
+  graph.xMax = max(graph.stats, roundOverride);
+  graph.xMin = min(graph.stats, roundOverride, graph.xMax);
+  if (secondField) {
+    graph.xMin = min(graph.secondStats, roundOverride, graph.xMax);
+  }
+  if (xMinOverride) {
+    graph.xMin = xMinOverride;
+  }
 
-    for(const indivStat of sortedStats) {
-        graph.stats.push(indivStat[field]);
-        if(secondField) {
-            graph.secondStats.push(indivStat[secondField]);
-        }
-        if(indivStat.managerID) {
-            graph.managerIDs.push(indivStat.managerID);
-            graph.rosterIDs.push(null);
-        } else if(indivStat.rosterID) {
-            graph.managerIDs.push(null);
-            graph.rosterIDs.push(indivStat.rosterID);
-        }
-    }
-
-    graph.xMax = max(graph.stats, roundOverride);
-    graph.xMin = min(graph.stats, roundOverride, graph.xMax);
-    if(secondField) {
-        graph.xMin = min(graph.secondStats, roundOverride, graph.xMax);
-    }
-    if(xMinOverride) {
-        graph.xMin = xMinOverride;
-    }
-
-    return graph;
-}
-
+  return graph;
+};
 
 /**
  * takes an array and array field, sorts the array, and returns
@@ -159,12 +186,12 @@ export const generateGraph = ({stats, x, stat, header, field, short, secondField
  * @param {string} field the field to sort on
  * @returns {arr|arr} [high, low] an array where the first element is the 10 highest records and the second is the 10 lowest elements
  */
- export const sortHighAndLow = (arr, field) => {
-	const sorted = arr.sort((a, b) => b[field] - a[field]);
-	const high = sorted.slice(0, 10);
-	const low = sorted.slice(-10).reverse();
-	return [high, low]
-}
+export const sortHighAndLow = (arr, field) => {
+  const sorted = arr.sort((a, b) => b[field] - a[field]);
+  const high = sorted.slice(0, 10);
+  const low = sorted.slice(-10).reverse();
+  return [high, low];
+};
 
 /**
  * get all managers of a roster
@@ -172,17 +199,17 @@ export const generateGraph = ({stats, x, stat, header, field, short, secondField
  * @returns {Object[]} [managerIDs...] an array of manager IDs
  */
 export const getManagers = (roster) => {
-	const managers = [];
-    if(roster.owner_id) {
-        managers.push(roster.owner_id);
+  const managers = [];
+  if (roster.owner_id) {
+    managers.push(roster.owner_id);
+  }
+  if (roster.co_owners) {
+    for (const coOwner of roster.co_owners) {
+      managers.push(coOwner);
     }
-    if(roster.co_owners) {
-        for(const coOwner of roster.co_owners) {
-            managers.push(coOwner);
-        }
-    }
-    return managers;
-}
+  }
+  return managers;
+};
 
 /**
  * takes in a map of users and a owner ID and returns an object with a user's avatar and name
@@ -191,119 +218,156 @@ export const getManagers = (roster) => {
  * @returns {Object} {avatar, name} an object containing a user's avatar image url and their name
  */
 export const getTeamData = (users, ownerID) => {
-	const user = users[ownerID];
-	if(user) {
-		return {
-			avatar: user.metadata?.avatar ? user.metadata.avatar : `https://sleepercdn.com/avatars/thumbs/${user.avatar}`,
-			name: user.metadata.team_name ? user.metadata.team_name : user.display_name,
-		}
-	}
+  const user = users[ownerID];
+  if (user) {
     return {
-        avatar: `https://sleepercdn.com/images/v2/icons/player_default.webp`,
-        name: 'Unknown Team',
-    }
-}
+      avatar: user.metadata?.avatar
+        ? user.metadata.avatar
+        : `https://sleepercdn.com/avatars/thumbs/${user.avatar}`,
+      name: user.metadata.team_name
+        ? user.metadata.team_name
+        : user.display_name,
+    };
+  }
+  return {
+    avatar: `https://sleepercdn.com/images/v2/icons/player_default.webp`,
+    name: "Unknown Team",
+  };
+};
 
 export const getAvatarFromTeamManagers = (teamManagers, rosterID, year) => {
-    if(!year || year > teamManagers.currentSeason) {
-        year = teamManagers.currentSeason;
-    }
-    const yearManagers = teamManagers.teamManagersMap[year];
-    if(yearManagers == null) {
-        return QUESTION;
-    }
-    const roster = yearManagers[rosterID];
-    if(roster == null) {
-        return QUESTION;
-    }
-    return roster.team?.avatar;
-}
+  if (!year || year > teamManagers.currentSeason) {
+    year = teamManagers.currentSeason;
+  }
+  const yearManagers = teamManagers.teamManagersMap[year];
+  if (yearManagers == null) {
+    return QUESTION;
+  }
+  const roster = yearManagers[rosterID];
+  if (roster == null) {
+    return QUESTION;
+  }
+  return roster.team?.avatar;
+};
 
 export const getTeamNameFromTeamManagers = (teamManagers, rosterID, year) => {
-    if(!year || year > teamManagers.currentSeason) {
-        year = teamManagers.currentSeason;
-    }
-    return teamManagers.teamManagersMap[year][rosterID].team.name;
-}
+  if (!year || year > teamManagers.currentSeason) {
+    year = teamManagers.currentSeason;
+  }
+  return teamManagers.teamManagersMap[year][rosterID].team.name;
+};
 
 export const renderManagerNames = (teamManagers, rosterID, year) => {
-    if(!year || year > teamManagers.currentSeason) {
-        year = teamManagers.currentSeason;
+  if (!year || year > teamManagers.currentSeason) {
+    year = teamManagers.currentSeason;
+  }
+  let managersString = "";
+  for (const managerID of teamManagers.teamManagersMap[year][rosterID]
+    .managers) {
+    const manager = teamManagers.users[managerID];
+    if (manager) {
+      if (managersString != "") {
+        managersString += ", ";
+      }
+      managersString += manager.display_name;
     }
-    let managersString = "";
-    for(const managerID of teamManagers.teamManagersMap[year][rosterID].managers) {
-        const manager = teamManagers.users[managerID];
-        if(manager) {
-            if(managersString != "") {
-                managersString += ", "
-            }
-            managersString += manager.display_name;
-        }
-    }
-    return managersString;
-}
+  }
+  return managersString;
+};
 
 export const getTeamFromTeamManagers = (teamManagers, rosterID, year) => {
-    if(!year || year > teamManagers.currentSeason) {
-        year = teamManagers.currentSeason;
-    }
-    return teamManagers.teamManagersMap[year][rosterID]['team'];
-}
+  if (!year || year > teamManagers.currentSeason) {
+    year = teamManagers.currentSeason;
+  }
+  return teamManagers.teamManagersMap[year][rosterID]["team"];
+};
 
-export const getNestedTeamNamesFromTeamManagers = (teamManagers, year, rosterID) => {
-    const originalName = teamManagers.teamManagersMap[year][rosterID]['team']['name'];
-    const currentName = teamManagers.teamManagersMap[teamManagers.currentSeason][rosterID]['team']['name'];
-    if(cleanName(originalName) != cleanName(currentName)) {
-        return `${originalName}<div class="curOwner">(${currentName})</div>`;
-    }
-    return originalName;
-}
+export const getNestedTeamNamesFromTeamManagers = (
+  teamManagers,
+  year,
+  rosterID,
+) => {
+  const originalName =
+    teamManagers.teamManagersMap[year][rosterID]["team"]["name"];
+  const currentName =
+    teamManagers.teamManagersMap[teamManagers.currentSeason][rosterID]["team"][
+      "name"
+    ];
+  if (cleanName(originalName) != cleanName(currentName)) {
+    return `${originalName}<div class="curOwner">(${currentName})</div>`;
+  }
+  return originalName;
+};
 
 export const getDatesActive = (teamManagers, managerID) => {
-    if(!managerID) return;
-    let datesActive = {start: null, end: null};
-    const years = Object.keys(teamManagers.teamManagersMap).sort((a, b) => b - a);
-    for(const year of years) {
-        for(const rosterID in  teamManagers.teamManagersMap[year]) {
-            if(teamManagers.teamManagersMap[year][rosterID].managers.indexOf(managerID) > -1) {
-                datesActive.start = year;
-                if(!datesActive.end) {
-                    datesActive.end = year;
-                }
-                break;
-            }
+  if (!managerID) return;
+  let datesActive = { start: null, end: null };
+  const years = Object.keys(teamManagers.teamManagersMap).sort((a, b) => b - a);
+  for (const year of years) {
+    for (const rosterID in teamManagers.teamManagersMap[year]) {
+      if (
+        teamManagers.teamManagersMap[year][rosterID].managers.indexOf(
+          managerID,
+        ) > -1
+      ) {
+        datesActive.start = year;
+        if (!datesActive.end) {
+          datesActive.end = year;
         }
+        break;
+      }
     }
-    if(datesActive.end == teamManagers.currentSeason) {
-        datesActive.end = null;
-    }
-    return datesActive;
-}
+  }
+  if (datesActive.end == teamManagers.currentSeason) {
+    datesActive.end = null;
+  }
+  return datesActive;
+};
 
 export const getRosterIDFromManagerID = (teamManagers, managerID) => {
-    if(!managerID) return null;
-    const years = Object.keys(teamManagers.teamManagersMap).sort((a, b) => b - a);
-    for(const year of years) {
-        for(const rosterID in  teamManagers.teamManagersMap[year]) {
-            if(teamManagers.teamManagersMap[year][rosterID].managers.indexOf(managerID) > -1) {
-                return {rosterID, year};
-            }
-        }
+  if (!managerID) return null;
+  const years = Object.keys(teamManagers.teamManagersMap).sort((a, b) => b - a);
+  for (const year of years) {
+    for (const rosterID in teamManagers.teamManagersMap[year]) {
+      if (
+        teamManagers.teamManagersMap[year][rosterID].managers.indexOf(
+          managerID,
+        ) > -1
+      ) {
+        return { rosterID, year };
+      }
     }
-    return null;
-}
+  }
+  return null;
+};
 
-export const getRosterIDFromManagerIDAndYear = (teamManagers, managerID, year) => {
-    if(!managerID || !year) return null;
-    for(const rosterID in  teamManagers.teamManagersMap[year]) {
-        if(teamManagers.teamManagersMap[year][rosterID].managers.indexOf(managerID) > -1) {
-            return rosterID;
-        }
+export const getRosterIDFromManagerIDAndYear = (
+  teamManagers,
+  managerID,
+  year,
+) => {
+  if (!managerID || !year) return null;
+  for (const rosterID in teamManagers.teamManagersMap[year]) {
+    if (
+      teamManagers.teamManagersMap[year][rosterID].managers.indexOf(managerID) >
+      -1
+    ) {
+      return rosterID;
     }
-    return null;
-}
+  }
+  return null;
+};
 
-export const checkIfManagerReceivedAward = (teamManagers, awardRosterID, year, managerID) => {
-    if(!managerID) return false;
-    return teamManagers.teamManagersMap[year][awardRosterID].managers.indexOf(managerID) > -1;
-}
+export const checkIfManagerReceivedAward = (
+  teamManagers,
+  awardRosterID,
+  year,
+  managerID,
+) => {
+  if (!managerID) return false;
+  return (
+    teamManagers.teamManagersMap[year][awardRosterID].managers.indexOf(
+      managerID,
+    ) > -1
+  );
+};

--- a/src/routes/player/+page.js
+++ b/src/routes/player/+page.js
@@ -1,0 +1,15 @@
+import {
+  loadPlayers,
+  getLeagueTransactions,
+  getLeagueTeamManagers,
+} from "$lib/utils/helper";
+
+export async function load({ url, fetch }) {
+  const playerID = url?.searchParams?.get("player");
+  return {
+    playerID,
+    playersData: loadPlayers(fetch),
+    transactionsData: getLeagueTransactions(),
+    leagueTeamManagersData: getLeagueTeamManagers(),
+  };
+}

--- a/src/routes/player/+page.svelte
+++ b/src/routes/player/+page.svelte
@@ -1,0 +1,38 @@
+<script>
+    import LinearProgress from '@smui/linear-progress';
+    import { Player } from '$lib/components';
+    import { waitForAll } from '$lib/utils/helper';
+
+    export let data;
+    const { playerID, playersData, transactionsData, leagueTeamManagersData } = data;
+</script>
+
+<style>
+    .holder {
+        position: relative;
+        z-index: 1;
+    }
+    .loading {
+        display: block;
+        width: 85%;
+        max-width: 500px;
+        margin: 80px auto;
+    }
+</style>
+
+<div class="holder">
+    {#await waitForAll(playersData, transactionsData, leagueTeamManagersData)}
+        <div class="loading">
+            <p>Gathering player data...</p>
+            <LinearProgress indeterminate />
+        </div>
+    {:then [playersInfo, transactionsInfo, leagueTeamManagers]}
+        {#if playerID && playersInfo.players[playerID]}
+            <Player {playerID} {playersInfo} {transactionsInfo} {leagueTeamManagers} />
+        {:else}
+            <p>Player not found.</p>
+        {/if}
+    {:catch error}
+        <p>Something went wrong: {error.message}</p>
+    {/await}
+</div>


### PR DESCRIPTION
## Summary
- add Player component and export it
- create a route to show information about a single player
- allow clicking players in rosters and transactions to open the new page
- support navigation with `gotoPlayer`
- store player id in roster data

## Testing
- `npm run lint` *(fails: Code style issues, prettier not run)*

------
https://chatgpt.com/codex/tasks/task_e_685cef7448408323a62eadc326f02b20