### PR TITLE
Improve loading indicator UI

### DIFF
--- a/src/lib/BlogPosts/FullPost.svelte
+++ b/src/lib/BlogPosts/FullPost.svelte
@@ -1,5 +1,5 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
+        import { LoadingSpinner } from '$lib/components';
     import { generateParagraph, waitForAll } from "$lib/utils/helper";
     import { onMount } from "svelte";
     import Comments from "./Comments.svelte";
@@ -199,8 +199,7 @@
 {#if loading}
     <!-- promise is pending -->
     <div class="loading">
-        <p>Loading Blog Post...</p>
-        <LinearProgress indeterminate />
+        <LoadingSpinner message="Loading Blog Post..." />
     </div>
 {:else if safePost}
     <div class="post">

--- a/src/lib/BlogPosts/HomePost.svelte
+++ b/src/lib/BlogPosts/HomePost.svelte
@@ -1,6 +1,6 @@
 <script>
     import { onMount } from "svelte";
-	import LinearProgress from '@smui/linear-progress';
+        import { LoadingSpinner } from '$lib/components';
     import Post from "./Post.svelte";
     import { getBlogPosts, getLeagueTeamManagers, waitForAll } from "$lib/utils/helper";
 
@@ -75,8 +75,7 @@
 {#if loading}
     <!-- promise is pending -->
     <div class="loading">
-        <p>Loading Blog Posts...</p>
-        <LinearProgress indeterminate />
+        <LoadingSpinner message="Loading Blog Posts..." />
     </div>
 {:else}
     <h2>League Blog</h2>

--- a/src/lib/BlogPosts/Posts.svelte
+++ b/src/lib/BlogPosts/Posts.svelte
@@ -2,7 +2,7 @@
     import { goto } from "$app/navigation";
     import Pagination from "$lib/Pagination.svelte";
     import { getBlogPosts, leagueName, waitForAll } from "$lib/utils/helper";
-    import LinearProgress from "@smui/linear-progress";
+    import { LoadingSpinner } from "$lib/components";
     import { onMount } from "svelte";
     import Post from "./Post.svelte";
     import { browser } from '$app/environment';
@@ -145,8 +145,7 @@
 
 {#if loading}
     <div class="loading" >
-        <p>Loading league blog posts...</p>
-        <LinearProgress indeterminate />
+        <LoadingSpinner message="Loading league blog posts..." />
     </div>
 {:else}
     <div class="filterButtons">

--- a/src/lib/Drafts/index.svelte
+++ b/src/lib/Drafts/index.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { waitForAll } from '$lib/utils/helper';
-    import LinearProgress from '@smui/linear-progress';
+    import { LoadingSpinner } from '$lib/components';
     import Draft from './Draft.svelte'; 
 
     export let upcomingDraftData, previousDraftsData, leagueTeamManagersData, playersData;
@@ -25,11 +25,9 @@
 
 
 {#await waitForAll(upcomingDraftData, leagueTeamManagersData, playersData) }
-	<div class="loading">
-		<p>Retrieving upcoming draft...</p>
-		<br />
-		<LinearProgress indeterminate />
-	</div>
+        <div class="loading">
+                <LoadingSpinner message="Retrieving upcoming draft..." />
+        </div>
 {:then [upcomingDraft, leagueTeamManagers, {players}] }
     <h4>Upcoming {upcomingDraft.year} Draft</h4>
     <Draft draftData={upcomingDraft} {leagueTeamManagers} year={upcomingDraft.year} {players} />
@@ -40,13 +38,11 @@
 
 
 {#await waitForAll(previousDraftsData, leagueTeamManagersData, playersData) }
-	<hr />
-	<h4>Previous Drafts</h4>
-	<div class="loading">
-		<p>Retrieving previous drafts...</p>
-		<br />
-		<LinearProgress indeterminate />
-	</div>
+        <hr />
+        <h4>Previous Drafts</h4>
+        <div class="loading">
+                <LoadingSpinner message="Retrieving previous drafts..." />
+        </div>
 {:then [previousDrafts, leagueTeamManagers, {players}] }
 	<!-- Don't display anything unless there are previous drafts -->
 	{#if previousDrafts.length}

--- a/src/lib/LoadingSpinner.svelte
+++ b/src/lib/LoadingSpinner.svelte
@@ -1,0 +1,56 @@
+<script>
+    export let message = 'Loading...';
+</script>
+
+<style>
+    .container {
+        display: block;
+        width: 85%;
+        max-width: 500px;
+        margin: 80px auto;
+        text-align: center;
+    }
+
+    .spinner {
+        display: inline-block;
+        position: relative;
+        width: 64px;
+        height: 16px;
+    }
+
+    .spinner div {
+        position: absolute;
+        top: 0;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--blueTwo);
+        animation: spinner-bounce 0.8s infinite ease-in-out;
+    }
+
+    .spinner div:nth-child(1) {
+        left: 0px;
+        animation-delay: -0.32s;
+    }
+    .spinner div:nth-child(2) {
+        left: 16px;
+        animation-delay: -0.16s;
+    }
+    .spinner div:nth-child(3) {
+        left: 32px;
+    }
+
+    @keyframes spinner-bounce {
+        0%, 80%, 100% { transform: scale(0); }
+        40% { transform: scale(1); }
+    }
+</style>
+
+<div class="container">
+    <p>{message}</p>
+    <div class="spinner">
+        <div></div>
+        <div></div>
+        <div></div>
+    </div>
+</div>

--- a/src/lib/Managers/Manager.svelte
+++ b/src/lib/Managers/Manager.svelte
@@ -1,6 +1,6 @@
 <script>
     import Button, { Group, Label } from '@smui/button';
-	import LinearProgress from '@smui/linear-progress';
+        import { LoadingSpinner } from '$lib/components';
     import {loadPlayers, getLeagueTransactions} from '$lib/utils/helper';
 	import Roster from '../Rosters/Roster.svelte';
 	import TransactionsPage from '../Transactions/TransactionsPage.svelte';
@@ -308,8 +308,7 @@
     {#if loading}
         <!-- promise is pending -->
         <div class="loading">
-            <p>Retrieving players...</p>
-            <LinearProgress indeterminate />
+            <LoadingSpinner message="Retrieving players..." />
         </div>
     {:else}
         <Roster division="1" expanded={false} {rosterPositions} {roster} {leagueTeamManagers} {players} {startersAndReserve} />
@@ -320,8 +319,7 @@
         {#if loading}
             <!-- promise is pending -->
             <div class="loading">
-                <p>Retrieving players...</p>
-                <LinearProgress indeterminate />
+                <LoadingSpinner message="Retrieving players..." />
             </div>
         {:else}
             <TransactionsPage {playersInfo} transactions={teamTransactions} {leagueTeamManagers} show='both' query='' page={0} perPage={5} />

--- a/src/lib/Matchups/MatchupsAndBrackets.svelte
+++ b/src/lib/Matchups/MatchupsAndBrackets.svelte
@@ -1,7 +1,7 @@
 
 <script>
-	import LinearProgress from '@smui/linear-progress';
-	import MatchupWeeks from './MatchupWeeks.svelte';
+        import MatchupWeeks from './MatchupWeeks.svelte';
+        import { LoadingSpinner } from '$lib/components';
 	import Brackets from './Brackets.svelte';
     import Button, { Group, Label } from '@smui/button';
     import { goto } from '$app/navigation';
@@ -67,8 +67,7 @@
 {#if loading}
     <!-- promise is pending -->
     <div class="message">
-        <p>Loading league matchups...</p>
-        <LinearProgress indeterminate />
+        <LoadingSpinner message="Loading league matchups..." />
     </div>
 {:else}
     {#if matchupWeeks.length}

--- a/src/lib/PowerRankings/index.svelte
+++ b/src/lib/PowerRankings/index.svelte
@@ -1,7 +1,7 @@
 <script>
     import {getNflState, getLeagueRosters, getLeagueTeamManagers, waitForAll, loadPlayers, getLeagueData} from '$lib/utils/helper';
     import PowerRankingsDisplay from './PowerRankingsDisplay.svelte';
-    import LinearProgress from '@smui/linear-progress';
+    import { LoadingSpinner } from '$lib/components';
     
     const helperPromises = waitForAll(
         getNflState(),
@@ -25,8 +25,7 @@
 {#await helperPromises}
     <!-- promise is pending -->
     <div class="loading">
-        <p>Calculating power rankings...</p>
-        <LinearProgress indeterminate />
+        <LoadingSpinner message="Calculating power rankings..." />
     </div>
 {:then [nflState, rostersData, leagueTeamManagers, leagueData, playersInfo]}
     {#if leagueData.status != 'pre_draft' && leagueData.status != 'complete'}

--- a/src/lib/Rivalry/index.svelte
+++ b/src/lib/Rivalry/index.svelte
@@ -3,7 +3,7 @@
 	import TradeTransaction from "$lib/Transactions/TradeTransaction.svelte";
 	import { getLeagueRecords, getLeagueTransactions, getRivalryMatchups, loadPlayers, round } from "$lib/utils/helper";
 	import { getRosterIDFromManagerIDAndYear } from "$lib/utils/helperFunctions/universalFunctions";
-	import LinearProgress from '@smui/linear-progress';
+        import { LoadingSpinner } from '$lib/components';
 	import { onMount } from "svelte";
 	import ComparissonBar from "./ComparissonBar.svelte";
 	import ManagerSelectors from "./ManagerSelectors.svelte";
@@ -165,9 +165,7 @@
 {#if loading }
     {#if playerOne && playerTwo }
         <div class="loading">
-            <p>Analyzing rivalry...</p>
-            <br />
-            <LinearProgress indeterminate />
+            <LoadingSpinner message="Analyzing rivalry..." />
         </div>
     {:else}
         <div class="center">

--- a/src/lib/Standings/index.svelte
+++ b/src/lib/Standings/index.svelte
@@ -1,8 +1,8 @@
 <script>
     import { leagueName, round } from '$lib/utils/helper';
 	import { getTeamFromTeamManagers } from '$lib/utils/helperFunctions/universalFunctions';
-  	import DataTable, { Head, Body, Row, Cell } from '@smui/data-table';
-	import LinearProgress from '@smui/linear-progress';
+        import DataTable, { Head, Body, Row, Cell } from '@smui/data-table';
+        import { LoadingSpinner } from '$lib/components';
     import { onMount } from 'svelte';
     import Standing from './Standing.svelte';
 
@@ -83,8 +83,7 @@
 {#if loading}
     <!-- promise is pending -->
     <div class="loading">
-        <p>Loading Standings...</p>
-        <LinearProgress indeterminate />
+        <LoadingSpinner message="Loading Standings..." />
     </div>
 {:else if preseason}
 <div class="loading">

--- a/src/lib/Transactions/Transactions.svelte
+++ b/src/lib/Transactions/Transactions.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { goto } from '$app/navigation';
-	import { getLeagueTransactions, getLeagueTeamManagers, loadPlayers, waitForAll } from '$lib/utils/helper';
-	import LinearProgress from '@smui/linear-progress';
+        import { getLeagueTransactions, getLeagueTeamManagers, loadPlayers, waitForAll } from '$lib/utils/helper';
+        import { LoadingSpinner } from '$lib/components';
 	import { onMount } from 'svelte';
 	import TradeTransaction from './TradeTransaction.svelte';
 	import WaiverTransaction from './WaiverTransaction.svelte';
@@ -63,9 +63,8 @@
 </style>
 
 <div class="transactions">
-	{#if loading}
-		<p>Loading league transactions...</p>
-		<LinearProgress indeterminate />
+        {#if loading}
+                <LoadingSpinner message="Loading league transactions..." />
 	{:else}
 		<!-- waiver -->
 		{#if transactions.waivers.length}

--- a/src/lib/components.js
+++ b/src/lib/components.js
@@ -18,6 +18,7 @@ import HomePost from './BlogPosts/HomePost.svelte';
 import FullPost from './BlogPosts/FullPost.svelte';
 import Posts from './BlogPosts/Posts.svelte';
 import Standings from './Standings/index.svelte';
+import LoadingSpinner from './LoadingSpinner.svelte';
 
 export {
     Nav,
@@ -40,4 +41,5 @@ export {
     Posts,
     FullPost,
     Standings,
+    LoadingSpinner,
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,6 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
-	import { getNflState, leagueName, getAwards, getLeagueTeamManagers, homepageText, managers, gotoManager, enableBlog, waitForAll } from '$lib/utils/helper';
-	import { Transactions, PowerRankings, HomePost} from '$lib/components';
+        import { getNflState, leagueName, getAwards, getLeagueTeamManagers, homepageText, managers, gotoManager, enableBlog, waitForAll } from '$lib/utils/helper';
+        import { Transactions, PowerRankings, HomePost, LoadingSpinner } from '$lib/components';
 	import { getAvatarFromTeamManagers, getTeamFromTeamManagers } from '$lib/utils/helperFunctions/universalFunctions';
 
     const nflState = getNflState();
@@ -153,8 +152,9 @@
     <div class="leagueData">
         <div class="homeBanner">
             {#await nflState}
-                <div class="center">Retrieving NFL state...</div>
-                <LinearProgress indeterminate />
+                <div class="center">
+                    <LoadingSpinner message="Retrieving NFL state..." />
+                </div>
             {:then nflStateData}
                 <div class="center">NFL {nflStateData.season} 
                     {#if nflStateData.season_type == 'pre'}
@@ -172,8 +172,9 @@
 
         <div id="currentChamp">
             {#await waitForAll(podiumsData, leagueTeamManagersData)}
-                <p class="center">Retrieving awards...</p>
-                <LinearProgress indeterminate />
+                <div class="center">
+                    <LoadingSpinner message="Retrieving awards..." />
+                </div>
             {:then [podiums, leagueTeamManagers]}
                 {#if podiums[0]}
                     <h4>{podiums[0].year} Fantasy Champ</h4>

--- a/src/routes/awards/+page.svelte
+++ b/src/routes/awards/+page.svelte
@@ -1,7 +1,6 @@
 <script>
-	import { Awards } from '$lib/components'
-	import { waitForAll } from '$lib/utils/helper';
-	import LinearProgress from '@smui/linear-progress';
+        import { Awards, LoadingSpinner } from '$lib/components'
+        import { waitForAll } from '$lib/utils/helper';
 
     export let data;
     const {awardsData, teamManagersData} = data;
@@ -35,11 +34,10 @@
 </style>
 
 <div class="awards">
-	{#await waitForAll(awardsData, teamManagersData) }
-		<div class="loading">
-			<p>Retrieving awards data...</p>
-			<LinearProgress indeterminate />
-		</div>
+        {#await waitForAll(awardsData, teamManagersData) }
+                <div class="loading">
+                        <LoadingSpinner message="Retrieving awards data..." />
+                </div>
 	{:then [podiums, leagueTeamManagers] }
 		{#each podiums as podium}
 			<Awards {podium} {leagueTeamManagers} />

--- a/src/routes/manager/+page.svelte
+++ b/src/routes/manager/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
-    import {Manager} from '$lib/components';
+        import {Manager, LoadingSpinner} from '$lib/components';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 
@@ -27,11 +26,10 @@
 </style>
 
 <div class="main">
-        {#await managersInfo}
+    {#await managersInfo}
             <!-- promise is pending -->
             <div class="loading">
-                <p>Retrieving managers...</p>
-                <LinearProgress indeterminate />
+                <LoadingSpinner message="Retrieving managers..." />
             </div>
         {:then [rostersData, leagueTeamManagers, leagueData, transactionsData, awards, records]}
             {#if managers.length && manager > -1}

--- a/src/routes/managers/+page.svelte
+++ b/src/routes/managers/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
-    import {AllManagers} from '$lib/components';
+        import {AllManagers, LoadingSpinner} from '$lib/components';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 
@@ -19,21 +18,12 @@
 		position: relative;
 		z-index: 1;
 	}
-    .loading {
-        display: block;
-        width: 85%;
-        max-width: 500px;
-        margin: 80px auto;
-    }
 </style>
 
 <div class="main">
     {#await leagueTeamManagersData}
         <!-- promise is pending -->
-        <div class="loading">
-            <p>Retrieving managers...</p>
-            <LinearProgress indeterminate />
-        </div>
+        <LoadingSpinner message="Retrieving managers..." />
     {:then leagueTeamManagers}
         {#if managers.length}
             <AllManagers {managers}  {leagueTeamManagers}/>

--- a/src/routes/records/+page.svelte
+++ b/src/routes/records/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
-	import { Records } from '$lib/components';
+        import { Records, LoadingSpinner } from '$lib/components';
 
     export let data;
     const recordsInfo = data.recordsInfo;
@@ -11,21 +10,12 @@
         position: relative;
         z-index: 1;
     }
-    .loading {
-        display: block;
-        width: 85%;
-        max-width: 500px;
-        margin: 80px auto;
-    }
 </style>
 
 <div id="main">
     {#await recordsInfo}
         <!-- promise is pending -->
-        <div class="loading">
-            <p>Loading league records...</p>
-            <LinearProgress indeterminate />
-        </div>
+        <LoadingSpinner message="Loading league records..." />
     {:then [leagueData, {totals, stale}, leagueTeamManagers]}
         <Records {leagueData} {totals} {stale} {leagueTeamManagers} />
     {:catch error}

--- a/src/routes/resources/+page.svelte
+++ b/src/routes/resources/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
-	import { News, Resources } from '$lib/components';
+        import { News, Resources, LoadingSpinner } from '$lib/components';
 
 	export let data;
 	const articlesData = data.articlesData;
@@ -21,11 +20,9 @@
 <hr />
 
 {#await articlesData}
-	<div class="loading">
-		<p>Retrieving fantasy news...</p>
-		<br />
-		<LinearProgress indeterminate />
-	</div>
+        <div class="loading">
+                <LoadingSpinner message="Retrieving fantasy news..." />
+        </div>
 {:then news}
 	<!-- promise was fulfilled -->
 	<News {news}/>

--- a/src/routes/rivalry/+page.svelte
+++ b/src/routes/rivalry/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
-	import { Rivalry } from '$lib/components'
+        import { Rivalry, LoadingSpinner } from '$lib/components'
 	import { waitForAll } from '$lib/utils/helper';
 
 	export let data;
@@ -19,21 +18,11 @@
 		position: relative;
 		z-index: 1;
 	}
-	.loading {
-		display: block;
-		width: 85%;
-		max-width: 500px;
-		margin: 80px auto;
-	}
 </style>
 
 <div class="holder">
-	{#await waitForAll(leagueTeamManagerData, playersData, transactionsData, recordsData)}
-		<div class="loading">
-			<p>Gathering information...</p>
-			<br />
-			<LinearProgress indeterminate />
-		</div>
+        {#await waitForAll(leagueTeamManagerData, playersData, transactionsData, recordsData)}
+                <LoadingSpinner message="Gathering information..." />
 	{:then [leagueTeamManagers, playersInfo, transactionsInfo, recordsInfo]}
 		<!-- promise was fulfilled -->
 		<Rivalry {leagueTeamManagers} {playersInfo} {transactionsInfo} {recordsInfo} {playerOne} {playerTwo} />

--- a/src/routes/rosters/+page.svelte
+++ b/src/routes/rosters/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
-	import { Rosters } from '$lib/components'
+        import { Rosters, LoadingSpinner } from '$lib/components'
 
 	export let data;
 	const rostersInfo = data.rostersInfo;
@@ -11,21 +10,11 @@
 		position: relative;
 		z-index: 1;
 	}
-	.loading {
-		display: block;
-		width: 85%;
-		max-width: 500px;
-		margin: 80px auto;
-	}
 </style>
 
 <div class="holder">
-	{#await rostersInfo}
-		<div class="loading">
-			<p>Retrieving roster data...</p>
-			<br />
-			<LinearProgress indeterminate />
-		</div>
+        {#await rostersInfo}
+                <LoadingSpinner message="Retrieving roster data..." />
 	{:then [leagueData, rosterData, leagueTeamManagers, playersInfo]}
 		<!-- promise was fulfilled -->
 		<Rosters {leagueData} {rosterData} {leagueTeamManagers} {playersInfo} /> <!-- displays rosters -->

--- a/src/routes/transactions/+page.svelte
+++ b/src/routes/transactions/+page.svelte
@@ -1,6 +1,5 @@
 <script>
-	import LinearProgress from '@smui/linear-progress';
-	import { TransactionsPage } from '$lib/components'
+        import { TransactionsPage, LoadingSpinner } from '$lib/components'
     import { waitForAll } from '$lib/utils/helper';
 
     export let data;
@@ -33,8 +32,7 @@
 <div id="main">
     {#await waitForAll(transactionsData, playersData, leagueTeamManagersData)}
         <div class="loading" >
-            <p>Loading league transactions...</p>
-            <LinearProgress indeterminate />
+            <LoadingSpinner message="Loading league transactions..." />
         </div>
     {:then [{transactions, currentTeams, stale}, playersInfo, leagueTeamManagers]}
         <TransactionsPage {playersInfo} {stale} {transactions} {currentTeams} {show} {query} queryPage={page} {perPage} postUpdate={true} {leagueTeamManagers} />


### PR DESCRIPTION
## Summary
- add a reusable LoadingSpinner component
- use LoadingSpinner across pages instead of the old progress bar

## Testing
- `npm run lint` *(fails: Code style issues found in 58 files)*

------
https://chatgpt.com/codex/tasks/task_e_685cef92da808323b1c83237b389bb61